### PR TITLE
[Usability] Minor improvements

### DIFF
--- a/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/DCPower/Source.cs
+++ b/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/DCPower/Source.cs
@@ -74,7 +74,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
         /// <param name="currentLimit">The current limit to use.</param>
         /// <param name="voltageLevelRange">The voltage level range to use.</param>
         /// <param name="currentLimitRange">The current limit range to use.</param>
-        public static void ForceVoltage(this DCPowerSessionsBundle sessionsBundle, double voltageLevel, double currentLimit, double? voltageLevelRange = null, double? currentLimitRange = null)
+        public static void ForceVoltage(this DCPowerSessionsBundle sessionsBundle, double voltageLevel, double? currentLimit = null, double? voltageLevelRange = null, double? currentLimitRange = null)
         {
             var settings = new DCPowerSourceSettings()
             {
@@ -99,7 +99,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
         /// <param name="currentLimit">The current limit to use.</param>
         /// <param name="voltageLevelRange">The voltage level range to use.</param>
         /// <param name="currentLimitRange">The current limit range to use.</param>
-        internal static void ForceVoltage(this DCPowerSessionsBundle sessionsBundle, IDictionary<string, double> voltageLevels, double currentLimit, double? voltageLevelRange = null, double? currentLimitRange = null)
+        internal static void ForceVoltage(this DCPowerSessionsBundle sessionsBundle, IDictionary<string, double> voltageLevels, double? currentLimit = null, double? voltageLevelRange = null, double? currentLimitRange = null)
         {
             sessionsBundle.Do((sessionInfo, sitePinInfo) =>
             {
@@ -124,7 +124,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
         /// <param name="currentLimit">The current limit to use.</param>
         /// <param name="voltageLevelRange">The voltage level range to use.</param>
         /// <param name="currentLimitRange">The current limit range to use.</param>
-        public static void ForceVoltage(this DCPowerSessionsBundle sessionsBundle, PinSiteData<double> voltageLevels, double currentLimit, double? voltageLevelRange = null, double? currentLimitRange = null)
+        public static void ForceVoltage(this DCPowerSessionsBundle sessionsBundle, PinSiteData<double> voltageLevels, double? currentLimit = null, double? voltageLevelRange = null, double? currentLimitRange = null)
         {
             sessionsBundle.Do((sessionInfo, sitePinInfo) =>
             {
@@ -192,7 +192,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
         /// <param name="voltageLimit">The voltage limit to use.</param>
         /// <param name="currentLevelRange">The current level range to use.</param>
         /// <param name="voltageLimitRange">The voltage limit range to use.</param>
-        public static void ForceCurrent(this DCPowerSessionsBundle sessionsBundle, double currentLevel, double voltageLimit, double? currentLevelRange = null, double? voltageLimitRange = null)
+        public static void ForceCurrent(this DCPowerSessionsBundle sessionsBundle, double currentLevel, double? voltageLimit = null, double? currentLevelRange = null, double? voltageLimitRange = null)
         {
             var settings = new DCPowerSourceSettings()
             {
@@ -524,6 +524,41 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
             {
                 sessionInfo.Session.Outputs[pinSiteInfo.IndividualChannelString].Control.Abort();
                 sessionInfo.Session.Outputs[pinSiteInfo.IndividualChannelString].Source.Output.Enabled = enableOutput.GetValue(pinSiteInfo.SiteNumber, pinSiteInfo.PinName);
+            });
+        }
+
+        /// <summary>
+        /// Configures the source delay.
+        /// With overrides for <see cref="SiteData{Double}" />, and <see cref="PinSiteData{Double}"/> input.
+        /// </summary>
+        /// <param name="sessionsBundle">The <see cref="DCPowerSessionsBundle"/> object.</param>
+        /// <param name="sourceDelayInSeconds">The double value of the source delay in seconds.</param>
+        public static void ConfigureSourceDelayInSeconds(this DCPowerSessionsBundle sessionsBundle, double sourceDelayInSeconds)
+        {
+            sessionsBundle.Do(sessionInfo =>
+            {
+                sessionInfo.AllChannelsOutput.Control.Abort();
+                sessionInfo.AllChannelsOutput.Source.SourceDelay = PrecisionTimeSpan.FromSeconds(sourceDelayInSeconds);
+            });
+        }
+
+        /// <inheritdoc cref="ConfigureSourceDelayInSeconds(DCPowerSessionsBundle, double)"/>
+        public static void ConfigureSourceDelayInSeconds(this DCPowerSessionsBundle sessionsBundle, SiteData<double> sourceDelayInSeconds)
+        {
+            sessionsBundle.Do((sessionInfo, pinSiteInfo) =>
+            {
+                sessionInfo.Session.Outputs[pinSiteInfo.IndividualChannelString].Control.Abort();
+                sessionInfo.Session.Outputs[pinSiteInfo.IndividualChannelString].Source.SourceDelay = PrecisionTimeSpan.FromSeconds(sourceDelayInSeconds.GetValue(pinSiteInfo.SiteNumber));
+            });
+        }
+
+        /// <inheritdoc cref="ConfigureSourceDelayInSeconds(DCPowerSessionsBundle, double)"/>
+        public static void ConfigureSourceDelayInSeconds(this DCPowerSessionsBundle sessionsBundle, PinSiteData<double> sourceDelayInSeconds)
+        {
+            sessionsBundle.Do((sessionInfo, pinSiteInfo) =>
+            {
+                sessionInfo.Session.Outputs[pinSiteInfo.IndividualChannelString].Control.Abort();
+                sessionInfo.Session.Outputs[pinSiteInfo.IndividualChannelString].Source.SourceDelay = PrecisionTimeSpan.FromSeconds(sourceDelayInSeconds.GetValue(pinSiteInfo.SiteNumber, pinSiteInfo.PinName));
             });
         }
 

--- a/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/Digital/PPMU.cs
+++ b/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/Digital/PPMU.cs
@@ -31,7 +31,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Dig
             double? apertureTime = null,
             double? settlingTime = null)
         {
-            var settings = new PPMUForcingSettings
+            var settings = new PPMUSettings
             {
                 OutputFunction = PpmuOutputFunction.DCVoltage,
                 VoltageLevel = voltageLevel,
@@ -64,7 +64,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Dig
         {
             sessionsBundle.Do((sessionInfo, sitePinInfo) =>
             {
-                var settings = new PPMUForcingSettings
+                var settings = new PPMUSettings
                 {
                     OutputFunction = PpmuOutputFunction.DCVoltage,
                     VoltageLevel = voltageLevels.GetValue(sitePinInfo.SiteNumber),
@@ -94,7 +94,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Dig
         {
             sessionsBundle.Do((sessionInfo, sitePinInfo) =>
             {
-                var settings = new PPMUForcingSettings
+                var settings = new PPMUSettings
                 {
                     OutputFunction = PpmuOutputFunction.DCVoltage,
                     VoltageLevel = voltageLevels.GetValue(sitePinInfo.SiteNumber, sitePinInfo.PinName),
@@ -111,7 +111,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Dig
         /// </summary>
         /// <param name="sessionsBundle">The <see cref="DigitalSessionsBundle"/> object.</param>
         /// <param name="settings">The per-pin settings to use.</param>
-        public static void ForceVoltage(this DigitalSessionsBundle sessionsBundle, IDictionary<string, PPMUForcingSettings> settings)
+        public static void ForceVoltage(this DigitalSessionsBundle sessionsBundle, IDictionary<string, PPMUSettings> settings)
         {
             sessionsBundle.Do((sessionInfo, sitePinInfo) =>
             {
@@ -140,7 +140,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Dig
             double? apertureTime = null,
             double? settlingTime = null)
         {
-            var settings = new PPMUForcingSettings
+            var settings = new PPMUSettings
             {
                 OutputFunction = PpmuOutputFunction.DCCurrent,
                 CurrentLevel = currentLevel,
@@ -162,7 +162,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Dig
         /// </summary>
         /// <param name="sessionsBundle">The <see cref="DigitalSessionsBundle"/> object.</param>
         /// <param name="settings">The per-pin settings to use.</param>
-        public static void ForceCurrent(this DigitalSessionsBundle sessionsBundle, IDictionary<string, PPMUForcingSettings> settings)
+        public static void ForceCurrent(this DigitalSessionsBundle sessionsBundle, IDictionary<string, PPMUSettings> settings)
         {
             sessionsBundle.Do((sessionInfo, sitePinInfo) =>
             {
@@ -409,7 +409,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Dig
         /// <param name="session">The <see cref="NIDigital"/> session.</param>
         /// <param name="pinSetString">The pin set string.</param>
         /// <param name="settings">The forcing settings.</param>
-        public static void Force(this NIDigital session, string pinSetString, PPMUForcingSettings settings)
+        public static void Force(this NIDigital session, string pinSetString, PPMUSettings settings)
         {
             var ppmu = session.PinAndChannelMap.GetPinSet(pinSetString).Ppmu;
             ppmu.OutputFunction = settings.OutputFunction;
@@ -433,7 +433,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Dig
 
         #region private methods
 
-        private static void ConfigureVoltageSettings(DigitalPpmu ppmu, PPMUForcingSettings settings)
+        private static void ConfigureVoltageSettings(DigitalPpmu ppmu, PPMUSettings settings)
         {
             if (settings.CurrentLimitRange.HasValue)
             {
@@ -442,7 +442,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Dig
             ppmu.DCVoltage.VoltageLevel = settings.VoltageLevel;
         }
 
-        private static void ConfigureCurrentSettings(DigitalPpmu ppmu, PPMUForcingSettings settings)
+        private static void ConfigureCurrentSettings(DigitalPpmu ppmu, PPMUSettings settings)
         {
             ppmu.DCCurrent.CurrentLevelRange = settings.CurrentLevelRange ?? Math.Min(0.032, Math.Max(2e-6, Math.Abs(settings.CurrentLevel)));
             ppmu.DCCurrent.CurrentLevel = settings.CurrentLevel;
@@ -456,9 +456,9 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Dig
     }
 
     /// <summary>
-    /// Defines settings for PPMU forcing.
+    /// Defines settings for PPMU.
     /// </summary>
-    public class PPMUForcingSettings
+    public class PPMUSettings
     {
         /// <summary>
         /// The output function.
@@ -508,7 +508,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Dig
         /// <summary>
         /// Default constructor.
         /// </summary>
-        public PPMUForcingSettings()
+        public PPMUSettings()
         {
         }
     }

--- a/SemiconductorTestLibrary.Extensions/test/Unit/InstrumentAbstraction/Digital/PPMUTests.cs
+++ b/SemiconductorTestLibrary.Extensions/test/Unit/InstrumentAbstraction/Digital/PPMUTests.cs
@@ -121,10 +121,10 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
             var sessionManager = InitializeSessionsAndCreateSessionManager("TwoDevicesWorkForTwoSitesSeparately.pinmap", "TwoDevicesWorkForTwoSitesSeparately.digiproj");
 
             var sessionsBundle = sessionManager.Digital(new string[] { "C0", "C1" });
-            var settings = new Dictionary<string, PPMUForcingSettings>()
+            var settings = new Dictionary<string, PPMUSettings>()
             {
-                ["C0"] = new PPMUForcingSettings() { VoltageLevel = 3.5, ApertureTime = 0.05 },
-                ["C1"] = new PPMUForcingSettings() { VoltageLevel = 5 },
+                ["C0"] = new PPMUSettings() { VoltageLevel = 3.5, ApertureTime = 0.05 },
+                ["C1"] = new PPMUSettings() { VoltageLevel = 5 },
             };
             sessionsBundle.ForceVoltage(settings);
 
@@ -144,10 +144,10 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
             var sessionManager = InitializeSessionsAndCreateSessionManager("OneDeviceWorksForOnePinOnTwoSites.pinmap", "OneDeviceWorksForOnePinOnTwoSites.digiproj");
 
             var sessionsBundle = sessionManager.Digital(new string[] { "C0", "C1" });
-            var settings = new Dictionary<string, PPMUForcingSettings>()
+            var settings = new Dictionary<string, PPMUSettings>()
             {
-                ["C0"] = new PPMUForcingSettings() { VoltageLevel = 3.5 },
-                ["C1"] = new PPMUForcingSettings() { VoltageLevel = 5, ApertureTime = 0.05 },
+                ["C0"] = new PPMUSettings() { VoltageLevel = 3.5 },
+                ["C1"] = new PPMUSettings() { VoltageLevel = 5, ApertureTime = 0.05 },
             };
             sessionsBundle.ForceVoltage(settings);
 
@@ -178,10 +178,10 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
             var sessionManager = InitializeSessionsAndCreateSessionManager("TwoDevicesWorkForTwoSitesSeparately.pinmap", "TwoDevicesWorkForTwoSitesSeparately.digiproj");
 
             var sessionsBundle = sessionManager.Digital(new string[] { "C0", "C1" });
-            var settings = new Dictionary<string, PPMUForcingSettings>()
+            var settings = new Dictionary<string, PPMUSettings>()
             {
-                ["C0"] = new PPMUForcingSettings() { CurrentLevel = 0.01, ApertureTime = 0.05 },
-                ["C1"] = new PPMUForcingSettings() { CurrentLevel = 0.02 },
+                ["C0"] = new PPMUSettings() { CurrentLevel = 0.01, ApertureTime = 0.05 },
+                ["C1"] = new PPMUSettings() { CurrentLevel = 0.02 },
             };
             sessionsBundle.ForceCurrent(settings);
 
@@ -201,10 +201,10 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
             var sessionManager = InitializeSessionsAndCreateSessionManager("OneDeviceWorksForOnePinOnTwoSites.pinmap", "OneDeviceWorksForOnePinOnTwoSites.digiproj");
 
             var sessionsBundle = sessionManager.Digital(new string[] { "C0", "C1" });
-            var settings = new Dictionary<string, PPMUForcingSettings>()
+            var settings = new Dictionary<string, PPMUSettings>()
             {
-                ["C0"] = new PPMUForcingSettings() { CurrentLevel = 0.01 },
-                ["C1"] = new PPMUForcingSettings() { CurrentLevel = 0.02, ApertureTime = 0.05 },
+                ["C0"] = new PPMUSettings() { CurrentLevel = 0.01 },
+                ["C1"] = new PPMUSettings() { CurrentLevel = 0.02, ApertureTime = 0.05 },
             };
             sessionsBundle.ForceCurrent(settings);
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

1. Make `voltage/currentLimit` optional parameter for `ForceVoltage/Current` APIs to match inline document.
2. Add `ConfigureSourceDelayInSeconds` APIs to directly configure source delay.
3. Rename `PPMUForcingSettings` type to `PPMUSettings`.

### Why should this Pull Request be merged?

This change is to improve usability.

### What testing has been done?

Existing tests pass.
