### PR TITLE
Update gh-pages-deploy.yml Workflow to Include Docfx PDF Generation Step

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -2,18 +2,14 @@
 name: Deploy static content to Pages
 
 on:
-  # Runs on pushes targeting the default branch
+  # Runs on pushes targeting the gh-pages branch that update the docs directory.
   push:
     branches:
     - gh-pages
     paths:
       - 'docs/**'
 
-  # Allows you to run this workflow manually from the Actions tab
-  # Temporary for testing purposes.
-  workflow_dispatch:
-
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages.
 permissions:
   contents: read
   pages: write


### PR DESCRIPTION
### What does this Pull Request accomplish?

Updates the gh-pages-deploy.yml workflow to include an step to perform pdf generation with docfx.

It also removes the manual trigger on for the workflow as it is no longer needed. 

### Why should this Pull Request be merged?

This step is required for the download PDF button on the hosted GitHub pages site to work. Currently, it will return 404 page not found, since the PDF files are not being generated by the build step alone.

Reference: https://dotnet.github.io/docfx/docs/pdf.html 

### What testing has been done?

Manually tested this on VM, the added `docfx pdf` command generates the PDFs for the `_site` files as expected.
