### PR TITLE
Use local sense when initializing DCPower for the TestStandSteps integration test

### DIFF
--- a/SemiconductorTestLibrary.TestStandSteps/tests/Integration/ContinuityTestTests.cs
+++ b/SemiconductorTestLibrary.TestStandSteps/tests/Integration/ContinuityTestTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using NationalInstruments.ModularInstruments.NIDCPower;
 using Xunit;
 using static NationalInstruments.SemiconductorTestLibrary.TestStandSteps.CommonSteps;
 using static NationalInstruments.SemiconductorTestLibrary.TestStandSteps.SetupAndCleanupSteps;
@@ -13,7 +14,7 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Integration
         public void Initialize_RunContinuityTestWithNegativeCurrentLevel_Succeeds()
         {
             var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
-            SetupNIDCPowerInstrumentation(tsmContext);
+            SetupNIDCPowerInstrumentation(tsmContext, measurementSense: DCPowerMeasurementSense.Local);
 
            ContinuityTest(
                tsmContext,


### PR DESCRIPTION
### What does this Pull Request accomplish?

Specify DCPower measurement sense to local sense instead of using the default remote sense.

### Why should this Pull Request be merged?

Use remote sense fails the test on a test environment where the sensing line is floating.

### What testing has been done?

Rely on ATS.
