### PR TITLE
Update CSProjects to Exclude net48 Path From Being Added To Project

### DIFF
--- a/SemiconductorTestLibrary.Extensions/source/SemiconductorTestLibrary.Extensions.csproj
+++ b/SemiconductorTestLibrary.Extensions/source/SemiconductorTestLibrary.Extensions.csproj
@@ -12,6 +12,11 @@
     <AssemblyName>NationalInstruments.SemiconductorTestLibrary.Extensions</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Remove="net48\**" />
+    <EmbeddedResource Remove="net48\**" />
+    <None Remove="net48\**" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="NI.CSharp.Analyzers" Version="1.2.8" />
     <Reference Include="Ivi.Driver">
       <SpecificVersion>False</SpecificVersion>

--- a/SemiconductorTestLibrary.TestStandSteps/source/SemiconductorTestLibrary.TestStandSteps.csproj
+++ b/SemiconductorTestLibrary.TestStandSteps/source/SemiconductorTestLibrary.TestStandSteps.csproj
@@ -12,6 +12,11 @@
     <AssemblyName>NationalInstruments.SemiconductorTestLibrary.TestStandSteps</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Remove="net48\**" />
+    <EmbeddedResource Remove="net48\**" />
+    <None Remove="net48\**" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="NI.CSharp.Analyzers" Version="1.2.8" />
     <ProjectReference Include="..\..\SemiconductorTestLibrary.Extensions\source\SemiconductorTestLibrary.Extensions.csproj" />
     <Reference Include="NationalInstruments.ModularInstruments.NIDmm.Fx40">


### PR DESCRIPTION
### What does this Pull Request accomplish?

Updates the TestStandSteps and Extensions csproject files to exclude net48 path from being included as a folder within the project, known to cause build issues in certain situations.

### Why should this Pull Request be merged?

This will reduce chances of erroneous build conflicts for contributors.

### What testing has been done?

None.
