### PR TITLE
Correct setting of voltage limits when forcing PPMU current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,7 +165,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - ### Changed
 
-  - `LeakageTest` TestStand step now forces 0V on all pins at start of test and after measuring. It also now ensures all pins are forced to the specified voltage before measuring current. Finally, it will now disable the output of all pins at the end of the test.
   - DMM Mulipoint extension methods now return `PinSiteData<double[]>` instead of a 2D per-instrument, per-sample array `double[][]`
     - `PinSiteData<double[]> ReadMultiPoint(this DMMSessionsBundle sessionsBundle, int numberOfPoints, double maximumTimeInMilliseconds)`
     - `PinSiteData<double[]> FetchMultiPoint(this DMMSessionsBundle sessionsBundle, int numberOfPoints, double maximumTimeInMilliseconds)`
@@ -175,6 +174,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     - For `SiteData<T>` objects, the scalar value will be applied to all elements in the array, across each site.
   - `Utilities.TryDeterminePowerLineFrequency` updated to now support OfflineMode.
   - `TestStandSteps.ContinuityTest` modified to correctly accept negative current level values.
+  - `TestStandSteps.LeakageTest` now forces 0V on all pins at start of test and after measuring. It also now ensures all pins are forced to the specified voltage level before measuring current. Finally, it will now disable the output of all pins at the end of the test. The method summary documentation has also been updated to reflect this change.
+  - `TestStandSteps.ForceDcCurrent` now correctly applies the specified voltage limit symmetrically for PPMU pins and has updated method summary documentation to reflect this change. 
+  - `TestStandSteps.ForceCurrentMeasureVoltage` now correctly applies symmetric voltage limits for PPMU pins and has updated method summary documentation to reflect this change.
   - CSProject files for TestStandSteps and Extensions now exclude net48 path from being included as a folder within the project, which could cause build issues for contributors in certain situations.
   - Improved documentation for the following DCPower extension methods: `ConfigureOutputEnabled`, `ConfigureOutputConnected`, `PowerDown`.
 

--- a/SemiconductorTestLibrary.TestStandSteps/source/ForceCurrentMeasureVoltage.cs
+++ b/SemiconductorTestLibrary.TestStandSteps/source/ForceCurrentMeasureVoltage.cs
@@ -13,10 +13,16 @@ namespace NationalInstruments.SemiconductorTestLibrary.TestStandSteps
     {
         /// <summary>
         /// Forces the specified DC current on all pins and/or pin groups specified, waits the specified amount of settling time,
-        /// and then measures the voltage on those pins and publishes the results to TestStand. Both DCPower and Digital PPMU pins are supported.
-        /// Both the <paramref name="settlingTime"/> and <paramref name="apertureTime"/> inputs are expected to be provided in Seconds.
-        /// By default the <paramref name="apertureTime"/> input is set to -1, which will cause this input to be ignored
+        /// and then measures the voltage on those pins and publishes the results to TestStand.
+        /// Note that the voltage measurements are published separately for each pin, regardless of if a pin group is provided, using the following Published Data Id: Voltage.
+        /// Both DCPower and Digital PPMU pins are supported.
+        /// Both the settlingTime and apertureTime inputs are expected to be provided in Seconds.
+        /// By default the apertureTime input is set to -1, which will cause this input to be ignored
         /// and the device will use any pre-configured aperture time set by a proceeding set, such as the Setup NI-DCPower Instrumentation step.
+        /// The absolute value of voltage limit will be applied symmetrically (i.e if voltageLimit = 1, the output voltage will be limited between -1V and +1V).
+        /// An exception will be thrown if the specified limit value is outside the high-end of the voltage limit range for any of the mapped instruments.
+        /// For Digital PPMU pins, since the voltage range of the digital pattern instruments is typically not symmetrically (i.e. -2V to 6V),
+        /// the low-end of the applied voltage limit will be coerced to within range (i.e if voltageLimit = 3, the output voltage will be limited between -2V and +3V).
         /// </summary>
         /// <param name="tsmContext">The <see cref="ISemiconductorModuleContext"/> object.</param>
         /// <param name="pinsOrPinGroups">The pins or pin groups to force DC voltage on.</param>

--- a/SemiconductorTestLibrary.TestStandSteps/source/ForceCurrentMeasureVoltage.cs
+++ b/SemiconductorTestLibrary.TestStandSteps/source/ForceCurrentMeasureVoltage.cs
@@ -63,7 +63,8 @@ namespace NationalInstruments.SemiconductorTestLibrary.TestStandSteps
                             {
                                 digital.ConfigureApertureTime(apertureTime);
                             }
-                            digital.ForceCurrent(currentLevel, voltageLimitLow: voltageLimit, voltageLimitHigh: voltageLimit);
+                            var absoluteValueOfVoltageLimit = Math.Abs(voltageLimit);
+                            digital.ForceCurrent(currentLevel, voltageLimitLow: Math.Max(-2, -absoluteValueOfVoltageLimit), voltageLimitHigh: absoluteValueOfVoltageLimit);
                             PreciseWait(settlingTime);
                             digital.MeasureAndPublishVoltage("Voltage", out _);
                         }

--- a/SemiconductorTestLibrary.TestStandSteps/source/ForceCurrentMeasureVoltage.cs
+++ b/SemiconductorTestLibrary.TestStandSteps/source/ForceCurrentMeasureVoltage.cs
@@ -35,6 +35,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.TestStandSteps
             try
             {
                 var sessionManager = new TSMSessionManager(tsmContext);
+                var absoluteValueOfVoltageLimit = Math.Abs(voltageLimit);
                 InvokeInParallel(
                     () =>
                     {
@@ -48,7 +49,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.TestStandSteps
                             {
                                 dcPower.ConfigureMeasureSettings(new DCPowerMeasureSettings { ApertureTime = apertureTime });
                             }
-                            dcPower.ForceCurrent(currentLevel, voltageLimit, waitForSourceCompletion: true);
+                            dcPower.ForceCurrent(currentLevel, absoluteValueOfVoltageLimit, waitForSourceCompletion: true);
                             dcPower.MeasureAndPublishVoltage("Voltage", out _);
                             dcPower.ConfigureSourceDelay(originalSourceDelays);
                         }
@@ -63,7 +64,6 @@ namespace NationalInstruments.SemiconductorTestLibrary.TestStandSteps
                             {
                                 digital.ConfigureApertureTime(apertureTime);
                             }
-                            var absoluteValueOfVoltageLimit = Math.Abs(voltageLimit);
                             digital.ForceCurrent(currentLevel, voltageLimitLow: Math.Max(-2, -absoluteValueOfVoltageLimit), voltageLimitHigh: absoluteValueOfVoltageLimit);
                             PreciseWait(settlingTime);
                             digital.MeasureAndPublishVoltage("Voltage", out _);

--- a/SemiconductorTestLibrary.TestStandSteps/source/ForceDcCurrent.cs
+++ b/SemiconductorTestLibrary.TestStandSteps/source/ForceDcCurrent.cs
@@ -49,7 +49,8 @@ namespace NationalInstruments.SemiconductorTestLibrary.TestStandSteps
                         if (digitalPins.Any())
                         {
                             var digital = sessionManager.Digital(digitalPins);
-                            digital.ForceCurrent(currentLevel, voltageLimitLow: voltageLimit, voltageLimitHigh: voltageLimit);
+                            var absoluteValueOfVoltageLimit = Math.Abs(voltageLimit);
+                            digital.ForceCurrent(currentLevel, voltageLimitLow: Math.Max(-2, -absoluteValueOfVoltageLimit), voltageLimitHigh: absoluteValueOfVoltageLimit);
                             PreciseWait(settlingTime);
                         }
                     });

--- a/SemiconductorTestLibrary.TestStandSteps/source/ForceDcCurrent.cs
+++ b/SemiconductorTestLibrary.TestStandSteps/source/ForceDcCurrent.cs
@@ -30,6 +30,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.TestStandSteps
             try
             {
                 var sessionManager = new TSMSessionManager(tsmContext);
+                var absoluteValueOfVoltageLimit = Math.Abs(voltageLimit);
                 InvokeInParallel(
                     () =>
                     {
@@ -39,7 +40,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.TestStandSteps
                             var dcPower = sessionManager.DCPower(dcPowerPins);
                             var originalSourceDelays = dcPower.GetSourceDelayInSeconds();
                             dcPower.ConfigureSourceDelay(settlingTime);
-                            dcPower.ForceCurrent(currentLevel, voltageLimit);
+                            dcPower.ForceCurrent(currentLevel, absoluteValueOfVoltageLimit);
                             dcPower.ConfigureSourceDelay(originalSourceDelays);
                         }
                     },
@@ -49,7 +50,6 @@ namespace NationalInstruments.SemiconductorTestLibrary.TestStandSteps
                         if (digitalPins.Any())
                         {
                             var digital = sessionManager.Digital(digitalPins);
-                            var absoluteValueOfVoltageLimit = Math.Abs(voltageLimit);
                             digital.ForceCurrent(currentLevel, voltageLimitLow: Math.Max(-2, -absoluteValueOfVoltageLimit), voltageLimitHigh: absoluteValueOfVoltageLimit);
                             PreciseWait(settlingTime);
                         }

--- a/SemiconductorTestLibrary.TestStandSteps/source/ForceDcCurrent.cs
+++ b/SemiconductorTestLibrary.TestStandSteps/source/ForceDcCurrent.cs
@@ -14,6 +14,10 @@ namespace NationalInstruments.SemiconductorTestLibrary.TestStandSteps
         /// <summary>
         /// Forces the specified DC current on all pins and/or pin groups specified. Both DCPower and Digital PPMU pins are supported.
         /// If a value is provided to the settlingTimeInSeconds input, the method will wait the specified amount of settling time before continuing.
+        /// The absolute value of voltage limit will be applied symmetrically (i.e if voltageLimit = 1, the output voltage will be limited between -1V and +1V).
+        /// An exception will be thrown if the specified limit value is outside the high-end of the voltage limit range for any of the mapped instruments.
+        /// For Digital PPMU pins, since the voltage range of the digital pattern instruments is typically not symmetrically (i.e. -2V to 6V),
+        /// the low-end of the applied voltage limit will be coerced to within range (i.e if voltageLimit = 3, the output voltage will be limited between -2V and +3V).
         /// </summary>
         /// <param name="tsmContext">The <see cref="ISemiconductorModuleContext"/> object.</param>
         /// <param name="pinsOrPinGroups">The pins or pin groups to force DC voltage on.</param>

--- a/SemiconductorTestLibrary.TestStandSteps/tests/Integration/ForceCurrentMeasureVoltageTests.cs
+++ b/SemiconductorTestLibrary.TestStandSteps/tests/Integration/ForceCurrentMeasureVoltageTests.cs
@@ -1,0 +1,51 @@
+﻿using NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction;
+using Xunit;
+using static NationalInstruments.SemiconductorTestLibrary.Common.ParallelExecution;
+using static NationalInstruments.SemiconductorTestLibrary.TestStandSteps.CommonSteps;
+using static NationalInstruments.SemiconductorTestLibrary.TestStandSteps.SetupAndCleanupSteps;
+using static NationalInstruments.Tests.SemiconductorTestLibrary.Utilities.TSMContext;
+
+namespace NationalInstruments.Tests.SemiconductorTestLibrary.Integration
+{
+    [Collection("NonParallelizable")]
+    public class ForceCurrentMeasureVoltageTests
+    {
+        [Fact]
+        public void InitializeDigital_RunForceCurrentMeasureVoltageWithGreaterThan2VoltageLimit_VoltageLimitLowSetToNegativeTwo()
+        {
+            var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
+            SetupNIDigitalPatternInstrumentation(tsmContext);
+
+            ForceCurrentMeasureVoltage(
+                tsmContext,
+                pinsOrPinGroups: new[] { "DigitalPins" },
+                currentLevel: 0.005,
+                voltageLimit: 3.3,
+                apertureTime: 5e-5,
+                settlingTime: 5e-5);
+
+            var digital = new TSMSessionManager(tsmContext).Digital("DigitalPins");
+            digital.Do(sessionInfo => Assert.Equal(-2, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitLow));
+            CleanupInstrumentation(tsmContext);
+        }
+
+        [Fact]
+        public void InitializeDigital_RunForceCurrentMeasureVoltageWithLessThan2VoltageLimit_VoltageLimitLowSetToNegativeVoltageLimit()
+        {
+            var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
+            SetupNIDigitalPatternInstrumentation(tsmContext);
+
+            ForceCurrentMeasureVoltage(
+                tsmContext,
+                pinsOrPinGroups: new[] { "DigitalPins" },
+                currentLevel: 0.005,
+                voltageLimit: 1.3,
+                apertureTime: 5e-5,
+                settlingTime: 5e-5);
+
+            var digital = new TSMSessionManager(tsmContext).Digital("DigitalPins");
+            digital.Do(sessionInfo => Assert.Equal(-1.3, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitLow, 1));
+            CleanupInstrumentation(tsmContext);
+        }
+    }
+}

--- a/SemiconductorTestLibrary.TestStandSteps/tests/Integration/ForceCurrentMeasureVoltageTests.cs
+++ b/SemiconductorTestLibrary.TestStandSteps/tests/Integration/ForceCurrentMeasureVoltageTests.cs
@@ -1,4 +1,5 @@
-﻿using NationalInstruments.SemiconductorTestLibrary.Common;
+﻿using NationalInstruments.ModularInstruments.NIDCPower;
+using NationalInstruments.SemiconductorTestLibrary.Common;
 using NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction;
 using Xunit;
 using static NationalInstruments.SemiconductorTestLibrary.Common.ParallelExecution;
@@ -12,19 +13,25 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Integration
     public class ForceCurrentMeasureVoltageTests
     {
         [Fact]
-        public void InitializeDigital_RunForceCurrentMeasureVoltageWithPositiveInRangeVoltageLimit_VoltageLimitsCorrectlySet()
+        public void Initialize_RunForceCurrentMeasureVoltageWithPositiveInRangeVoltageLimit_VoltageLimitsCorrectlySet()
         {
             var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
+            SetupNIDCPowerInstrumentation(tsmContext, measurementSense: DCPowerMeasurementSense.Local);
             SetupNIDigitalPatternInstrumentation(tsmContext);
 
             ForceCurrentMeasureVoltage(
                 tsmContext,
-                pinsOrPinGroups: new[] { "DigitalPins" },
+                pinsOrPinGroups: new[] { "VCC1", "DigitalPins" },
                 currentLevel: 0.005,
                 voltageLimit: 3.3,
                 apertureTime: 5e-5,
                 settlingTime: 5e-5);
 
+            var dcPower = new TSMSessionManager(tsmContext).DCPower("VCC1");
+            dcPower.Do(sessionInfo =>
+            {
+                Assert.Equal(3.3, sessionInfo.AllChannelsOutput.Source.Current.VoltageLimit, 1);
+            });
             var digital = new TSMSessionManager(tsmContext).Digital("DigitalPins");
             digital.Do(sessionInfo =>
             {
@@ -35,19 +42,25 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Integration
         }
 
         [Fact]
-        public void InitializeDigital_RunForceCurrentMeasureVoltageWithPositiveOutRangeVoltageLimit_VoltageLimitsCorrectlySet()
+        public void Initialize_RunForceCurrentMeasureVoltageWithPositiveOutRangeVoltageLimit_VoltageLimitsCorrectlySet()
         {
             var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
+            SetupNIDCPowerInstrumentation(tsmContext, measurementSense: DCPowerMeasurementSense.Local);
             SetupNIDigitalPatternInstrumentation(tsmContext);
 
             ForceCurrentMeasureVoltage(
                 tsmContext,
-                pinsOrPinGroups: new[] { "DigitalPins" },
+                pinsOrPinGroups: new[] { "VCC1", "DigitalPins" },
                 currentLevel: 0.005,
                 voltageLimit: 1.3,
                 apertureTime: 5e-5,
                 settlingTime: 5e-5);
 
+            var dcPower = new TSMSessionManager(tsmContext).DCPower("VCC1");
+            dcPower.Do(sessionInfo =>
+            {
+                Assert.Equal(1.3, sessionInfo.AllChannelsOutput.Source.Current.VoltageLimit, 1);
+            });
             var digital = new TSMSessionManager(tsmContext).Digital("DigitalPins");
             digital.Do(sessionInfo =>
             {
@@ -58,19 +71,25 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Integration
         }
 
         [Fact]
-        public void InitializeDigital_RunForceCurrentMeasureVoltageWithNegativeInRangeVoltageLimit_VoltageLimitsCorrectlySet()
+        public void Initialize_RunForceCurrentMeasureVoltageWithNegativeInRangeVoltageLimit_VoltageLimitsCorrectlySet()
         {
             var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
+            SetupNIDCPowerInstrumentation(tsmContext, measurementSense: DCPowerMeasurementSense.Local);
             SetupNIDigitalPatternInstrumentation(tsmContext);
 
             ForceCurrentMeasureVoltage(
                 tsmContext,
-                pinsOrPinGroups: new[] { "DigitalPins" },
+                pinsOrPinGroups: new[] { "VCC1", "DigitalPins" },
                 currentLevel: 0.005,
                 voltageLimit: -1.3,
                 apertureTime: 5e-5,
                 settlingTime: 5e-5);
 
+            var dcPower = new TSMSessionManager(tsmContext).DCPower("VCC1");
+            dcPower.Do(sessionInfo =>
+            {
+                Assert.Equal(1.3, sessionInfo.AllChannelsOutput.Source.Current.VoltageLimit, 1);
+            });
             var digital = new TSMSessionManager(tsmContext).Digital("DigitalPins");
             digital.Do(sessionInfo =>
             {
@@ -81,19 +100,25 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Integration
         }
 
         [Fact]
-        public void InitializeDigital_RunForceCurrentMeasureVoltageWithNegativeOutRangeVoltageLimit_VoltageLimitsCorrectlySet()
+        public void Initialize_RunForceCurrentMeasureVoltageWithNegativeOutRangeVoltageLimit_VoltageLimitsCorrectlySet()
         {
             var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
+            SetupNIDCPowerInstrumentation(tsmContext, measurementSense: DCPowerMeasurementSense.Local);
             SetupNIDigitalPatternInstrumentation(tsmContext);
 
             ForceCurrentMeasureVoltage(
                 tsmContext,
-                pinsOrPinGroups: new[] { "DigitalPins" },
+                pinsOrPinGroups: new[] { "VCC1", "DigitalPins" },
                 currentLevel: 0.005,
                 voltageLimit: -3.3,
                 apertureTime: 5e-5,
                 settlingTime: 5e-5);
 
+            var dcPower = new TSMSessionManager(tsmContext).DCPower("VCC1");
+            dcPower.Do(sessionInfo =>
+            {
+                Assert.Equal(3.3, sessionInfo.AllChannelsOutput.Source.Current.VoltageLimit, 1);
+            });
             var digital = new TSMSessionManager(tsmContext).Digital("DigitalPins");
             digital.Do(sessionInfo =>
             {
@@ -104,14 +129,14 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Integration
         }
 
         [Fact]
-        public void InitializeDigital_RunForceCurrentMeasureVoltageWithOutHighRangeVoltageLimit_ThrowsException()
+        public void Initialize_RunForceCurrentMeasureVoltageWithOutHighRangeVoltageLimit_ThrowsException()
         {
             var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
             SetupNIDigitalPatternInstrumentation(tsmContext);
 
             void ForceCurrentMeasureVoltageMethod() => ForceCurrentMeasureVoltage(
                 tsmContext,
-                pinsOrPinGroups: new[] { "DigitalPins" },
+                pinsOrPinGroups: new[] { "VCC1", "DigitalPins" },
                 currentLevel: 0.005,
                 voltageLimit: 8,
                 apertureTime: 5e-5,

--- a/SemiconductorTestLibrary.TestStandSteps/tests/Integration/ForceCurrentMeasureVoltageTests.cs
+++ b/SemiconductorTestLibrary.TestStandSteps/tests/Integration/ForceCurrentMeasureVoltageTests.cs
@@ -11,7 +11,7 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Integration
     public class ForceCurrentMeasureVoltageTests
     {
         [Fact]
-        public void InitializeDigital_RunForceCurrentMeasureVoltageWithGreaterThan2VoltageLimit_VoltageLimitLowSetToNegativeTwo()
+        public void InitializeDigital_RunForceCurrentMeasureVoltageWithPositiveInRangeVoltageLimit_VoltageLimitsCorrectlySet()
         {
             var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
             SetupNIDigitalPatternInstrumentation(tsmContext);
@@ -25,12 +25,16 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Integration
                 settlingTime: 5e-5);
 
             var digital = new TSMSessionManager(tsmContext).Digital("DigitalPins");
-            digital.Do(sessionInfo => Assert.Equal(-2, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitLow));
+            digital.Do(sessionInfo =>
+            {
+                Assert.Equal(-2, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitLow);
+                Assert.Equal(3.3, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitHigh, 1);
+            });
             CleanupInstrumentation(tsmContext);
         }
 
         [Fact]
-        public void InitializeDigital_RunForceCurrentMeasureVoltageWithLessThan2VoltageLimit_VoltageLimitLowSetToNegativeVoltageLimit()
+        public void InitializeDigital_RunForceCurrentMeasureVoltageWithPositiveOutRangeVoltageLimit_VoltageLimitsCorrectlySet()
         {
             var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
             SetupNIDigitalPatternInstrumentation(tsmContext);
@@ -44,7 +48,57 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Integration
                 settlingTime: 5e-5);
 
             var digital = new TSMSessionManager(tsmContext).Digital("DigitalPins");
-            digital.Do(sessionInfo => Assert.Equal(-1.3, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitLow, 1));
+            digital.Do(sessionInfo =>
+            {
+                Assert.Equal(-1.3, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitLow, 1);
+                Assert.Equal(1.3, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitHigh, 1);
+            });
+            CleanupInstrumentation(tsmContext);
+        }
+
+        [Fact]
+        public void InitializeDigital_RunForceCurrentMeasureVoltageWithNegativeInRangeVoltageLimit_VoltageLimitsCorrectlySet()
+        {
+            var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
+            SetupNIDigitalPatternInstrumentation(tsmContext);
+
+            ForceCurrentMeasureVoltage(
+                tsmContext,
+                pinsOrPinGroups: new[] { "DigitalPins" },
+                currentLevel: 0.005,
+                voltageLimit: -1.3,
+                apertureTime: 5e-5,
+                settlingTime: 5e-5);
+
+            var digital = new TSMSessionManager(tsmContext).Digital("DigitalPins");
+            digital.Do(sessionInfo =>
+            {
+                Assert.Equal(-1.3, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitLow, 1);
+                Assert.Equal(1.3, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitHigh, 1);
+            });
+            CleanupInstrumentation(tsmContext);
+        }
+
+        [Fact]
+        public void InitializeDigital_RunForceCurrentMeasureVoltageWithNegativeOutRangeVoltageLimit_VoltageLimitsCorrectlySet()
+        {
+            var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
+            SetupNIDigitalPatternInstrumentation(tsmContext);
+
+            ForceCurrentMeasureVoltage(
+                tsmContext,
+                pinsOrPinGroups: new[] { "DigitalPins" },
+                currentLevel: 0.005,
+                voltageLimit: -3.3,
+                apertureTime: 5e-5,
+                settlingTime: 5e-5);
+
+            var digital = new TSMSessionManager(tsmContext).Digital("DigitalPins");
+            digital.Do(sessionInfo =>
+            {
+                Assert.Equal(-2, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitLow);
+                Assert.Equal(3.3, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitHigh, 1);
+            });
             CleanupInstrumentation(tsmContext);
         }
     }

--- a/SemiconductorTestLibrary.TestStandSteps/tests/Integration/ForceCurrentMeasureVoltageTests.cs
+++ b/SemiconductorTestLibrary.TestStandSteps/tests/Integration/ForceCurrentMeasureVoltageTests.cs
@@ -1,4 +1,5 @@
-﻿using NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction;
+﻿using NationalInstruments.SemiconductorTestLibrary.Common;
+using NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction;
 using Xunit;
 using static NationalInstruments.SemiconductorTestLibrary.Common.ParallelExecution;
 using static NationalInstruments.SemiconductorTestLibrary.TestStandSteps.CommonSteps;
@@ -99,6 +100,25 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Integration
                 Assert.Equal(-2, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitLow);
                 Assert.Equal(3.3, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitHigh, 1);
             });
+            CleanupInstrumentation(tsmContext);
+        }
+
+        [Fact]
+        public void InitializeDigital_RunForceCurrentMeasureVoltageWithOutHighRangeVoltageLimit_ThrowsException()
+        {
+            var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
+            SetupNIDigitalPatternInstrumentation(tsmContext);
+
+            void ForceCurrentMeasureVoltageMethod() => ForceCurrentMeasureVoltage(
+                tsmContext,
+                pinsOrPinGroups: new[] { "DigitalPins" },
+                currentLevel: 0.005,
+                voltageLimit: 8,
+                apertureTime: 5e-5,
+                settlingTime: 5e-5);
+
+            var exception = Assert.Throws<NISemiconductorTestException>(ForceCurrentMeasureVoltageMethod);
+            Assert.Contains("Maximum Value: 6", exception.Message);
             CleanupInstrumentation(tsmContext);
         }
     }

--- a/SemiconductorTestLibrary.TestStandSteps/tests/Integration/ForceDcCurrentTests.cs
+++ b/SemiconductorTestLibrary.TestStandSteps/tests/Integration/ForceDcCurrentTests.cs
@@ -1,4 +1,5 @@
-﻿using NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction;
+﻿using NationalInstruments.SemiconductorTestLibrary.Common;
+using NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction;
 using Xunit;
 using static NationalInstruments.SemiconductorTestLibrary.Common.ParallelExecution;
 using static NationalInstruments.SemiconductorTestLibrary.TestStandSteps.CommonSteps;
@@ -95,6 +96,24 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Integration
                 Assert.Equal(-2, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitLow);
                 Assert.Equal(3.3, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitHigh, 1);
             });
+            CleanupInstrumentation(tsmContext);
+        }
+
+        [Fact]
+        public void InitializeDigital_RunForceDcCurrentWithOutHighRangeVoltageLimit_ThrowsException()
+        {
+            var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
+            SetupNIDigitalPatternInstrumentation(tsmContext);
+
+            void ForceDcCurrentMethod() => ForceDcCurrent(
+                tsmContext,
+                pinsOrPinGroups: new[] { "DigitalPins" },
+                currentLevel: 0.005,
+                voltageLimit: 8,
+                settlingTime: 5e-5);
+
+            var exception = Assert.Throws<NISemiconductorTestException>(ForceDcCurrentMethod);
+            Assert.Contains("Maximum Value: 6", exception.Message);
             CleanupInstrumentation(tsmContext);
         }
     }

--- a/SemiconductorTestLibrary.TestStandSteps/tests/Integration/ForceDcCurrentTests.cs
+++ b/SemiconductorTestLibrary.TestStandSteps/tests/Integration/ForceDcCurrentTests.cs
@@ -1,0 +1,49 @@
+﻿using NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction;
+using Xunit;
+using static NationalInstruments.SemiconductorTestLibrary.Common.ParallelExecution;
+using static NationalInstruments.SemiconductorTestLibrary.TestStandSteps.CommonSteps;
+using static NationalInstruments.SemiconductorTestLibrary.TestStandSteps.SetupAndCleanupSteps;
+using static NationalInstruments.Tests.SemiconductorTestLibrary.Utilities.TSMContext;
+
+namespace NationalInstruments.Tests.SemiconductorTestLibrary.Integration
+{
+    [Collection("NonParallelizable")]
+    public class ForceDcCurrentTests
+    {
+        [Fact]
+        public void InitializeDigital_RunForceDcCurrentWithGreaterThan2VoltageLimit_VoltageLimitLowSetToNegativeTwo()
+        {
+            var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
+            SetupNIDigitalPatternInstrumentation(tsmContext);
+
+            ForceDcCurrent(
+                tsmContext,
+                pinsOrPinGroups: new[] { "DigitalPins" },
+                currentLevel: 0.005,
+                voltageLimit: 3.3,
+                settlingTime: 5e-5);
+
+            var digital = new TSMSessionManager(tsmContext).Digital("DigitalPins");
+            digital.Do(sessionInfo => Assert.Equal(-2, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitLow));
+            CleanupInstrumentation(tsmContext);
+        }
+
+        [Fact]
+        public void InitializeDigital_RunForceDcCurrentWithLessThan2VoltageLimit_VoltageLimitLowSetToNegativeVoltageLimit()
+        {
+            var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
+            SetupNIDigitalPatternInstrumentation(tsmContext);
+
+            ForceDcCurrent(
+                tsmContext,
+                pinsOrPinGroups: new[] { "DigitalPins" },
+                currentLevel: 0.005,
+                voltageLimit: 1.3,
+                settlingTime: 5e-5);
+
+            var digital = new TSMSessionManager(tsmContext).Digital("DigitalPins");
+            digital.Do(sessionInfo => Assert.Equal(-1.3, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitLow, 1));
+            CleanupInstrumentation(tsmContext);
+        }
+    }
+}

--- a/SemiconductorTestLibrary.TestStandSteps/tests/Integration/ForceDcCurrentTests.cs
+++ b/SemiconductorTestLibrary.TestStandSteps/tests/Integration/ForceDcCurrentTests.cs
@@ -1,4 +1,5 @@
-﻿using NationalInstruments.SemiconductorTestLibrary.Common;
+﻿using NationalInstruments.ModularInstruments.NIDCPower;
+using NationalInstruments.SemiconductorTestLibrary.Common;
 using NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction;
 using Xunit;
 using static NationalInstruments.SemiconductorTestLibrary.Common.ParallelExecution;
@@ -12,18 +13,24 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Integration
     public class ForceDcCurrentTests
     {
         [Fact]
-        public void InitializeDigital_RunForceDcCurrentWithPositiveInRangeVoltageLimit_VoltageLimitsCorrectlySet()
+        public void Initialize_RunForceDcCurrentWithPositiveInRangeVoltageLimit_VoltageLimitsCorrectlySet()
         {
             var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
+            SetupNIDCPowerInstrumentation(tsmContext, measurementSense: DCPowerMeasurementSense.Local);
             SetupNIDigitalPatternInstrumentation(tsmContext);
 
             ForceDcCurrent(
                 tsmContext,
-                pinsOrPinGroups: new[] { "DigitalPins" },
+                pinsOrPinGroups: new[] { "VCC1", "DigitalPins" },
                 currentLevel: 0.005,
                 voltageLimit: 1.3,
                 settlingTime: 5e-5);
 
+            var dcPower = new TSMSessionManager(tsmContext).DCPower("VCC1");
+            dcPower.Do(sessionInfo =>
+            {
+                Assert.Equal(1.3, sessionInfo.AllChannelsOutput.Source.Current.VoltageLimit, 1);
+            });
             var digital = new TSMSessionManager(tsmContext).Digital("DigitalPins");
             digital.Do(sessionInfo =>
             {
@@ -34,18 +41,24 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Integration
         }
 
         [Fact]
-        public void InitializeDigital_RunForceDcCurrentWithPositiveOutRangeVoltageLimit_VoltageLimitsCorrectlySet()
+        public void Initialize_RunForceDcCurrentWithPositiveOutRangeVoltageLimit_VoltageLimitsCorrectlySet()
         {
             var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
+            SetupNIDCPowerInstrumentation(tsmContext, measurementSense: DCPowerMeasurementSense.Local);
             SetupNIDigitalPatternInstrumentation(tsmContext);
 
             ForceDcCurrent(
                 tsmContext,
-                pinsOrPinGroups: new[] { "DigitalPins" },
+                pinsOrPinGroups: new[] { "VCC1", "DigitalPins" },
                 currentLevel: 0.005,
                 voltageLimit: 3.3,
                 settlingTime: 5e-5);
 
+            var dcPower = new TSMSessionManager(tsmContext).DCPower("VCC1");
+            dcPower.Do(sessionInfo =>
+            {
+                Assert.Equal(3.3, sessionInfo.AllChannelsOutput.Source.Current.VoltageLimit, 1);
+            });
             var digital = new TSMSessionManager(tsmContext).Digital("DigitalPins");
             digital.Do(sessionInfo =>
             {
@@ -56,18 +69,24 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Integration
         }
 
         [Fact]
-        public void InitializeDigital_RunForceDcCurrentWithNegativeInRangeVoltageLimit_VoltageLimitsCorrectlySet()
+        public void Initialize_RunForceDcCurrentWithNegativeInRangeVoltageLimit_VoltageLimitsCorrectlySet()
         {
             var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
+            SetupNIDCPowerInstrumentation(tsmContext, measurementSense: DCPowerMeasurementSense.Local);
             SetupNIDigitalPatternInstrumentation(tsmContext);
 
             ForceDcCurrent(
                 tsmContext,
-                pinsOrPinGroups: new[] { "DigitalPins" },
+                pinsOrPinGroups: new[] { "VCC1", "DigitalPins" },
                 currentLevel: 0.005,
                 voltageLimit: -1.3,
                 settlingTime: 5e-5);
 
+            var dcPower = new TSMSessionManager(tsmContext).DCPower("VCC1");
+            dcPower.Do(sessionInfo =>
+            {
+                Assert.Equal(1.3, sessionInfo.AllChannelsOutput.Source.Current.VoltageLimit, 1);
+            });
             var digital = new TSMSessionManager(tsmContext).Digital("DigitalPins");
             digital.Do(sessionInfo =>
             {
@@ -78,18 +97,24 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Integration
         }
 
         [Fact]
-        public void InitializeDigital_RunForceDcCurrentWithNegativeOutRangeVoltageLimit_VoltageLimitsCorrectlySet()
+        public void Initialize_RunForceDcCurrentWithNegativeOutRangeVoltageLimit_VoltageLimitsCorrectlySet()
         {
             var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
+            SetupNIDCPowerInstrumentation(tsmContext, measurementSense: DCPowerMeasurementSense.Local);
             SetupNIDigitalPatternInstrumentation(tsmContext);
 
             ForceDcCurrent(
                 tsmContext,
-                pinsOrPinGroups: new[] { "DigitalPins" },
+                pinsOrPinGroups: new[] { "VCC1", "DigitalPins" },
                 currentLevel: 0.005,
                 voltageLimit: -3.3,
                 settlingTime: 5e-5);
 
+            var dcPower = new TSMSessionManager(tsmContext).DCPower("VCC1");
+            dcPower.Do(sessionInfo =>
+            {
+                Assert.Equal(3.3, sessionInfo.AllChannelsOutput.Source.Current.VoltageLimit, 1);
+            });
             var digital = new TSMSessionManager(tsmContext).Digital("DigitalPins");
             digital.Do(sessionInfo =>
             {
@@ -100,14 +125,14 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Integration
         }
 
         [Fact]
-        public void InitializeDigital_RunForceDcCurrentWithOutHighRangeVoltageLimit_ThrowsException()
+        public void Initialize_RunForceDcCurrentWithOutHighRangeVoltageLimit_ThrowsException()
         {
             var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
             SetupNIDigitalPatternInstrumentation(tsmContext);
 
             void ForceDcCurrentMethod() => ForceDcCurrent(
                 tsmContext,
-                pinsOrPinGroups: new[] { "DigitalPins" },
+                pinsOrPinGroups: new[] { "VCC1", "DigitalPins" },
                 currentLevel: 0.005,
                 voltageLimit: 8,
                 settlingTime: 5e-5);

--- a/SemiconductorTestLibrary.TestStandSteps/tests/Integration/ForceDcCurrentTests.cs
+++ b/SemiconductorTestLibrary.TestStandSteps/tests/Integration/ForceDcCurrentTests.cs
@@ -11,25 +11,7 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Integration
     public class ForceDcCurrentTests
     {
         [Fact]
-        public void InitializeDigital_RunForceDcCurrentWithGreaterThan2VoltageLimit_VoltageLimitLowSetToNegativeTwo()
-        {
-            var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
-            SetupNIDigitalPatternInstrumentation(tsmContext);
-
-            ForceDcCurrent(
-                tsmContext,
-                pinsOrPinGroups: new[] { "DigitalPins" },
-                currentLevel: 0.005,
-                voltageLimit: 3.3,
-                settlingTime: 5e-5);
-
-            var digital = new TSMSessionManager(tsmContext).Digital("DigitalPins");
-            digital.Do(sessionInfo => Assert.Equal(-2, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitLow));
-            CleanupInstrumentation(tsmContext);
-        }
-
-        [Fact]
-        public void InitializeDigital_RunForceDcCurrentWithLessThan2VoltageLimit_VoltageLimitLowSetToNegativeVoltageLimit()
+        public void InitializeDigital_RunForceDcCurrentWithPositiveInRangeVoltageLimit_VoltageLimitsCorrectlySet()
         {
             var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
             SetupNIDigitalPatternInstrumentation(tsmContext);
@@ -42,7 +24,77 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Integration
                 settlingTime: 5e-5);
 
             var digital = new TSMSessionManager(tsmContext).Digital("DigitalPins");
-            digital.Do(sessionInfo => Assert.Equal(-1.3, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitLow, 1));
+            digital.Do(sessionInfo =>
+            {
+                Assert.Equal(-1.3, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitLow, 1);
+                Assert.Equal(1.3, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitHigh, 1);
+            });
+            CleanupInstrumentation(tsmContext);
+        }
+
+        [Fact]
+        public void InitializeDigital_RunForceDcCurrentWithPositiveOutRangeVoltageLimit_VoltageLimitsCorrectlySet()
+        {
+            var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
+            SetupNIDigitalPatternInstrumentation(tsmContext);
+
+            ForceDcCurrent(
+                tsmContext,
+                pinsOrPinGroups: new[] { "DigitalPins" },
+                currentLevel: 0.005,
+                voltageLimit: 3.3,
+                settlingTime: 5e-5);
+
+            var digital = new TSMSessionManager(tsmContext).Digital("DigitalPins");
+            digital.Do(sessionInfo =>
+            {
+                Assert.Equal(-2, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitLow);
+                Assert.Equal(3.3, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitHigh, 1);
+            });
+            CleanupInstrumentation(tsmContext);
+        }
+
+        [Fact]
+        public void InitializeDigital_RunForceDcCurrentWithNegativeInRangeVoltageLimit_VoltageLimitsCorrectlySet()
+        {
+            var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
+            SetupNIDigitalPatternInstrumentation(tsmContext);
+
+            ForceDcCurrent(
+                tsmContext,
+                pinsOrPinGroups: new[] { "DigitalPins" },
+                currentLevel: 0.005,
+                voltageLimit: -1.3,
+                settlingTime: 5e-5);
+
+            var digital = new TSMSessionManager(tsmContext).Digital("DigitalPins");
+            digital.Do(sessionInfo =>
+            {
+                Assert.Equal(-1.3, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitLow, 1);
+                Assert.Equal(1.3, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitHigh, 1);
+            });
+            CleanupInstrumentation(tsmContext);
+        }
+
+        [Fact]
+        public void InitializeDigital_RunForceDcCurrentWithNegativeOutRangeVoltageLimit_VoltageLimitsCorrectlySet()
+        {
+            var tsmContext = CreateTSMContext("Mixed Signal Tests.pinmap", "Mixed Signal Tests.digiproj");
+            SetupNIDigitalPatternInstrumentation(tsmContext);
+
+            ForceDcCurrent(
+                tsmContext,
+                pinsOrPinGroups: new[] { "DigitalPins" },
+                currentLevel: 0.005,
+                voltageLimit: -3.3,
+                settlingTime: 5e-5);
+
+            var digital = new TSMSessionManager(tsmContext).Digital("DigitalPins");
+            digital.Do(sessionInfo =>
+            {
+                Assert.Equal(-2, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitLow);
+                Assert.Equal(3.3, sessionInfo.PinSet.Ppmu.DCCurrent.VoltageLimitHigh, 1);
+            });
             CleanupInstrumentation(tsmContext);
         }
     }

--- a/SemiconductorTestLibrary.TestStandSteps/tests/Integration/LeakageTestTests.cs
+++ b/SemiconductorTestLibrary.TestStandSteps/tests/Integration/LeakageTestTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using NationalInstruments.ModularInstruments.NIDCPower;
+﻿using NationalInstruments.ModularInstruments.NIDCPower;
 using Xunit;
 using static NationalInstruments.SemiconductorTestLibrary.TestStandSteps.CommonSteps;
 using static NationalInstruments.SemiconductorTestLibrary.TestStandSteps.SetupAndCleanupSteps;

--- a/SemiconductorTestLibrary.TestStandSteps/tests/Tests.SemiconductorTestLibrary.TestStandSteps.csproj
+++ b/SemiconductorTestLibrary.TestStandSteps/tests/Tests.SemiconductorTestLibrary.TestStandSteps.csproj
@@ -19,6 +19,9 @@
     <Reference Include="NationalInstruments.ModularInstruments.NIDigital.Fx40">
       <SpecificVersion>False</SpecificVersion>
     </Reference>
+    <Reference Include="NationalInstruments.SemiconductorTestLibrary.Abstractions">
+      <HintPath>..\..\SemiconductorTestLibrary.Abstractions\NationalInstruments.SemiconductorTestLibrary.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="NationalInstruments.TestStand.SemiconductorModule.CodeModuleAPI">
       <SpecificVersion>False</SpecificVersion>
     </Reference>

--- a/SemiconductorTestLibrary.TestStandSteps/tests/Tests.SemiconductorTestLibrary.TestStandSteps.csproj
+++ b/SemiconductorTestLibrary.TestStandSteps/tests/Tests.SemiconductorTestLibrary.TestStandSteps.csproj
@@ -16,6 +16,9 @@
     <Reference Include="NationalInstruments.ModularInstruments.NIDCPower.Fx40">
       <SpecificVersion>False</SpecificVersion>
     </Reference>
+    <Reference Include="NationalInstruments.ModularInstruments.NIDigital.Fx40">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="NationalInstruments.TestStand.SemiconductorModule.CodeModuleAPI">
       <SpecificVersion>False</SpecificVersion>
     </Reference>


### PR DESCRIPTION
### What does this Pull Request accomplish?

Set voltage limit low to the negative value of voltage limit high. Do coercion when the negative value is out of NI Digital instrument's valid range.

### Why should this Pull Request be merged?

To addess this issue: https://github.com/ni/semi-test-library-dotnet/issues/136

### What testing has been done?

The new auto tests pass on local dev machines.
