### PR TITLE
Update CHANGELOG.md to Align with 24.5.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     - Improved documentation for the following DCPower extension methods: `ConfigureOutputEnabled`, `ConfigureOutputConnected`, `PowerDown`.
   - **TestStandSteps**
     - `ContinuityTest` modified to correctly accept negative current level values.
+    - `FilterPinsOrPinGroups` removed as a private method from ContinuityTest.cs, the `ContinuityTest` method now references the new public implementation for this method in the common `Utilities` class: `FilterPinsOrPinGroups`
     - `LeakageTest` now forces 0V on all pins at start of test and after measuring. It also now ensures all pins are forced to the specified voltage level before measuring current. Finally, it will now disable the output of all pins at the end of the test. The method summary documentation has also been updated to reflect this change.
     - `ForceDcCurrent` now correctly applies the specified voltage limit symmetrically for PPMU pins and has updated method summary documentation to reflect this change.
     - `ForceCurrentMeasureVoltage` now correctly applies symmetric voltage limits for PPMU pins and has updated method summary documentation to reflect this change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,20 +165,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - ### Changed
 
-  - DMM Mulipoint extension methods now return `PinSiteData<double[]>` instead of a 2D per-instrument, per-sample array `double[][]`
-    - `PinSiteData<double[]> ReadMultiPoint(this DMMSessionsBundle sessionsBundle, int numberOfPoints, double maximumTimeInMilliseconds)`
-    - `PinSiteData<double[]> FetchMultiPoint(this DMMSessionsBundle sessionsBundle, int numberOfPoints, double maximumTimeInMilliseconds)`
-  - Math Operations methods now support most common numeric data types with improved exceptions for catching unsupported types and input array size mismatches.
-  - Math Operations methods now support scalar input values when the underlying type, `T`, of the `SiteData<T>` or `PinSiteData<T>` object is an array type.
-    - For `PinSiteData<T>` objects, the scalar value will be applied to all elements in the array, across each pin and site.
-    - For `SiteData<T>` objects, the scalar value will be applied to all elements in the array, across each site.
-  - `Utilities.TryDeterminePowerLineFrequency` updated to now support OfflineMode.
-  - `TestStandSteps.ContinuityTest` modified to correctly accept negative current level values.
-  - `TestStandSteps.LeakageTest` now forces 0V on all pins at start of test and after measuring. It also now ensures all pins are forced to the specified voltage level before measuring current. Finally, it will now disable the output of all pins at the end of the test. The method summary documentation has also been updated to reflect this change.
-  - `TestStandSteps.ForceDcCurrent` now correctly applies the specified voltage limit symmetrically for PPMU pins and has updated method summary documentation to reflect this change. 
-  - `TestStandSteps.ForceCurrentMeasureVoltage` now correctly applies symmetric voltage limits for PPMU pins and has updated method summary documentation to reflect this change.
-  - CSProject files for TestStandSteps and Extensions now exclude net48 path from being included as a folder within the project, which could cause build issues for contributors in certain situations.
-  - Improved documentation for the following DCPower extension methods: `ConfigureOutputEnabled`, `ConfigureOutputConnected`, `PowerDown`.
+  - **Data Abstraction**
+    - Math Operations methods now support most common numeric data types with improved exceptions for catching unsupported types and input array size mismatches.
+    - Math Operations methods now support scalar input values when the underlying type, `T`, of the `SiteData<T>` or `PinSiteData<T>` object is an array type.
+      - For `PinSiteData<T>` objects, the scalar value will be applied to all elements in the array, across each pin and site.
+      - For `SiteData<T>` objects, the scalar value will be applied to all elements in the array, across each site.
+  - **Instrument Abstraction**
+    - DMM Multi-point extension methods now return `PinSiteData<double[]>` instead of a 2D per-instrument, per-sample array `double[][]`
+      - `PinSiteData<double[]> ReadMultiPoint(this DMMSessionsBundle sessionsBundle, int numberOfPoints, double maximumTimeInMilliseconds)`
+      - `PinSiteData<double[]> FetchMultiPoint(this DMMSessionsBundle sessionsBundle, int numberOfPoints, double maximumTimeInMilliseconds)`
+    - Improved documentation for the following DCPower extension methods: `ConfigureOutputEnabled`, `ConfigureOutputConnected`, `PowerDown`.
+  - **TestStandSteps**
+    - `ContinuityTest` modified to correctly accept negative current level values.
+    - `LeakageTest` now forces 0V on all pins at start of test and after measuring. It also now ensures all pins are forced to the specified voltage level before measuring current. Finally, it will now disable the output of all pins at the end of the test. The method summary documentation has also been updated to reflect this change.
+    - `ForceDcCurrent` now correctly applies the specified voltage limit symmetrically for PPMU pins and has updated method summary documentation to reflect this change.
+    - `ForceCurrentMeasureVoltage` now correctly applies symmetric voltage limits for PPMU pins and has updated method summary documentation to reflect this change.
+  - **Utilities**
+    - `Utilities.TryDeterminePowerLineFrequency` updated to now support OfflineMode.
+  - **GitHub Repo**
+    - CSProject files for TestStandSteps and Extensions now exclude net48 path from being included as a folder within the project, which could cause build issues for contributors in certain situations.
 
 ## 24.5.0 - 2024-08-16
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Organizes the Changed section of CHANGELOG.md to align with Added section for the 24.5.1 release.
Fixes typo: Mulipoint to Multipoint
Adds change to CHANGELOG.md regarding FilterPinsOrPinGroups private method being replaced in ContinuityTest method

### Why should this Pull Request be merged?

The Change section of the 24.5.1 release was not well organized previously, and this made it hard to follow. This change also aligns it with the content organization found in the with [releases page for the 24.5.1 release](https://github.com/ni/semi-test-library-dotnet/releases/tag/v24.5.1).

### What testing has been done?

Simple documentation update, no testing done or required.
