### PR TITLE
Create a seperate file to hold shared definitions

### DIFF
--- a/SemiconductorTestLibrary.TestStandSteps/source/CleanupInstrumentation.cs
+++ b/SemiconductorTestLibrary.TestStandSteps/source/CleanupInstrumentation.cs
@@ -82,56 +82,5 @@ namespace NationalInstruments.SemiconductorTestLibrary.TestStandSteps
                 NISemiconductorTestException.Throw(e);
             }
         }
-
-        /// <summary>
-        /// Defines NI instrument types the NI Semiconductor Test Library supports.
-        /// </summary>
-        public enum NIInstrumentType
-        {
-            /// <summary>
-            /// All NI instruments.
-            /// </summary>
-            All,
-
-            /// <summary>
-            /// An NI-DCPower instrument.
-            /// </summary>
-            NIDCPower,
-
-            /// <summary>
-            /// An NI-Digital Pattern instrument.
-            /// </summary>
-            NIDigitalPattern,
-
-            /// <summary>
-            /// A relay driver module (NI-SWITCH instrument).
-            /// </summary>
-            NIRelayDriver,
-
-            /// <summary>
-            /// An NI-DAQmx task.
-            /// </summary>
-            NIDAQmx,
-
-            /// <summary>
-            /// An NI-DMM instrument.
-            /// </summary>
-            NIDMM,
-
-            /// <summary>
-            /// An NI-FGEN instrument.
-            /// </summary>
-            NIFGen,
-
-            /// <summary>
-            /// An NI-SCOPE instrument.
-            /// </summary>
-            NIScope,
-
-            /// <summary>
-            /// An NI-Sync instrument.
-            /// </summary>
-            NISync
-        }
     }
 }

--- a/SemiconductorTestLibrary.TestStandSteps/source/DutPowerUp.cs
+++ b/SemiconductorTestLibrary.TestStandSteps/source/DutPowerUp.cs
@@ -100,15 +100,6 @@ namespace NationalInstruments.SemiconductorTestLibrary.TestStandSteps
             }
         }
 
-        private static void VerifySizeOfArrayInputs(string arrayNames, string[] pinsOrPinGroups, params double[][] perPinOrPinGroupValues)
-        {
-            var valuesArraysDistinctSizes = perPinOrPinGroupValues.Select(item => item.Length).Distinct();
-            if (valuesArraysDistinctSizes.Count() != 1 || valuesArraysDistinctSizes.Single() != pinsOrPinGroups.Length)
-            {
-                throw new NISemiconductorTestException(string.Format(CultureInfo.InvariantCulture, ResourceStrings.Parameter_ArraySizeMismatch, arrayNames));
-            }
-        }
-
         private static IDictionary<string, DCPowerSourceSettings> BuildDCPowerSourceSettings(IList<string[]> pins, IList<int> pinIndexes, double[] voltageLevels, double[] currentLimits)
         {
             var settings = new Dictionary<string, DCPowerSourceSettings>();

--- a/SemiconductorTestLibrary.TestStandSteps/source/Shared.cs
+++ b/SemiconductorTestLibrary.TestStandSteps/source/Shared.cs
@@ -1,0 +1,72 @@
+﻿using System.Globalization;
+using System.Linq;
+using NationalInstruments.SemiconductorTestLibrary.Common;
+
+namespace NationalInstruments.SemiconductorTestLibrary.TestStandSteps
+{
+    /// <summary>
+    /// This file contains shared methods and other definitions used by multiple TestStand steps.
+    /// </summary>
+    public static partial class CommonSteps
+    {
+        private static void VerifySizeOfArrayInputs(string arrayNames, string[] pinsOrPinGroups, params double[][] perPinOrPinGroupValues)
+        {
+            var valuesArraysDistinctSizes = perPinOrPinGroupValues.Select(item => item.Length).Distinct();
+            if (valuesArraysDistinctSizes.Count() != 1 || valuesArraysDistinctSizes.Single() != pinsOrPinGroups.Length)
+            {
+                throw new NISemiconductorTestException(string.Format(CultureInfo.InvariantCulture, ResourceStrings.Parameter_ArraySizeMismatch, arrayNames));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Defines NI instrument types the NI Semiconductor Test Library supports.
+    /// </summary>
+    public enum NIInstrumentType
+    {
+        /// <summary>
+        /// All NI instruments.
+        /// </summary>
+        All,
+
+        /// <summary>
+        /// An NI-DCPower instrument.
+        /// </summary>
+        NIDCPower,
+
+        /// <summary>
+        /// An NI-Digital Pattern instrument.
+        /// </summary>
+        NIDigitalPattern,
+
+        /// <summary>
+        /// A relay driver module (NI-SWITCH instrument).
+        /// </summary>
+        NIRelayDriver,
+
+        /// <summary>
+        /// An NI-DAQmx task.
+        /// </summary>
+        NIDAQmx,
+
+        /// <summary>
+        /// An NI-DMM instrument.
+        /// </summary>
+        NIDMM,
+
+        /// <summary>
+        /// An NI-FGEN instrument.
+        /// </summary>
+        NIFGen,
+
+        /// <summary>
+        /// An NI-SCOPE instrument.
+        /// </summary>
+        NIScope,
+
+        /// <summary>
+        /// An NI-Sync instrument.
+        /// </summary>
+        NISync
+    }
+}


### PR DESCRIPTION
### What does this Pull Request accomplish?

Create a Shared.cs file and move shared definitions (currently `NIInstrumentType `and `VerifySizeOfArrayInputs`) there.

### Why should this Pull Request be merged?

To address [this kind of usability issue](https://github.com/ni/semi-test-library-dotnet/issues/144) in a generic way.

### What testing has been done?

Project build passes.
