### PR TITLE
Fix href Path in Documentation Table of Contents

### DIFF
--- a/docs/UserGuide/toc.yml
+++ b/docs/UserGuide/toc.yml
@@ -39,7 +39,7 @@
 - name: Extending the Semiconductor Test Library
   href: advanced/ExtendingTheSemiconductorTestLibrary.md
 - name: Customizing TestStand Steps
-  href: CustomizingTestStandSteps.md
+  href: advanced/CustomizingTestStandSteps.md
 
 - name: TestStand Steps
 - name: Using TestStand Steps


### PR DESCRIPTION
### What does this Pull Request accomplish?

Corrects the href path in the documentation table of contents (introduced in #161)

### Why should this Pull Request be merged?

Docfx cannot build with the incorrect href path.

### What testing has been done?

Manually ran docfx build to confirm the href path is working (this step was mistakenly overlooked when submitting #161).
