### PR TITLE
[Minor] Fix to typecast run_number to string for contamination check

### DIFF
--- a/.github/workflows/pr-intake.yml
+++ b/.github/workflows/pr-intake.yml
@@ -15,6 +15,7 @@ on:
 
 env:
     GitHub_Repo_Name: "semi-test-library-dotnet"
+    Run_Number: "#${{ github.run_number }}"
 
 jobs:
   wait-for-pr-build-and-test-workflows:
@@ -49,7 +50,7 @@ jobs:
           fi
 
           # Assuming that the PR Build Workflow run has a display title containing the run number.
-          run_id=$(jq -r '.workflow_runs[] | select(.display_title | contains(${{ github.run_number }})) | .id' runs.json)
+          run_id=$(jq -r '.workflow_runs[] | select(.display_title | contains(${{ env.Run_Number }})) | .id' runs.json)
           
           echo "Fetched build run_id: $run_id"
           echo "::set-output name=build_run_id::$run_id"
@@ -78,7 +79,7 @@ jobs:
           fi
 
           # Assuming that the PR Test Workflow run has a display title containing the run number.
-          run_id=$(jq -r '.workflow_runs[] | select(.display_title | contains(${{ github.run_number }})) | .id' runs.json)
+          run_id=$(jq -r '.workflow_runs[] | select(.display_title | contains(${{ env.Run_Number }})) | .id' runs.json)
           
           echo "Fetched test run_id: $run_id"
           echo "::set-output name=test_run_id::$run_id"


### PR DESCRIPTION
### What does this Pull Request accomplish?

The pr-intake action fails because display_title as a string cannot compare to run_number as a number.

### Why should this Pull Request be merged?

A variable for run_number was added as a string to use in the steps below.

### What testing has been done?

NA
