### PR TITLE
Fix Example Code Implementation in ConcurrentCodeExecution.md and MeasureVoltageMixed.cs

### DIFF
--- a/Examples/source/InstrumentAbstraction/MeasureVoltageMixed.cs
+++ b/Examples/source/InstrumentAbstraction/MeasureVoltageMixed.cs
@@ -9,7 +9,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.Examples.InstrumentAbstra
 {
     /// <summary>
     /// This class contains examples of how to use the Instrument Abstraction extensions from the Semiconductor Test Library.
-    /// Specifically, how to measure current on pins that could be mapped to a DCPower instrument, Digital Pattern Instrument, or both.
+    /// Specifically, how to measure current on pins that could be mapped to a DCPower instrument, Digital Pattern Instrument, or Digital Multi Meter.
     /// Note that DCPower Instruments include both Source Measurement Units (SMUs) and Programmable Power Supplies (PPS) devices.
     /// This class, and it's methods are intended for example purposes only and are not meant to be ran standalone.
     /// They are only meant to demonstrate specific coding concepts and may otherwise assume a hypothetical test program
@@ -18,26 +18,40 @@ namespace NationalInstruments.SemiconductorTestLibrary.Examples.InstrumentAbstra
     /// </summary>
     internal static class MeasureVoltageMixed
     {
-        internal static void SimpleMeasureAndPublishCurrentSmuOrPpmu(ISemiconductorModuleContext tsmContext, string[] pinNames)
+        internal static void SimpleMeasureAndPublishCurrentSmuOrPpmuOrDmm(ISemiconductorModuleContext tsmContext, string[] pinNames)
         {
             var sessionManager = new TSMSessionManager(tsmContext);
-            var publishDataID = "Measurement";
-            var filteredPinNamesDmm = tsmContext.FilterPinsByInstrumentType(pinNames, InstrumentTypeIdConstants.NIDmm);
-            var filteredPinNamesPpmu = tsmContext.FilterPinsByInstrumentType(pinNames, InstrumentTypeIdConstants.NIDigitalPattern);
+            var publishedDataId = "Measurement";
             var filteredPinNamesSmu = tsmContext.FilterPinsByInstrumentType(pinNames, InstrumentTypeIdConstants.NIDCPower);
-            var ppmuPins = sessionManager.DCPower(filteredPinNamesSmu);
-            var smuPins = sessionManager.Digital(filteredPinNamesPpmu);
+            var filteredPinNamesPpmu = tsmContext.FilterPinsByInstrumentType(pinNames, InstrumentTypeIdConstants.NIDigitalPattern);
+            var filteredPinNamesDmm = tsmContext.FilterPinsByInstrumentType(pinNames, InstrumentTypeIdConstants.NIDmm);
+            var smuPins = sessionManager.DCPower(filteredPinNamesSmu);
+            var ppmuPins = sessionManager.Digital(filteredPinNamesPpmu);
             var dmmPins = sessionManager.DMM(filteredPinNamesPpmu);
 
             // Just an example of the InvokeInParallel method, assumes that the instrumentation is already configured.
             Utilities.InvokeInParallel(
-                () => ppmuPins.MeasureAndPublishCurrent(publishDataID),
-                () => smuPins.MeasureAndPublishCurrent(publishDataID),
-                () =>
-                {
-                    var measurements = dmmPins.Read(maximumTimeInMilliseconds: 2000);
-                    tsmContext.PublishResults(measurements, publishDataID);
-                });
+                () => ppmuPins.MeasureAndPublishCurrent(publishedDataId),
+                () => smuPins.MeasureAndPublishCurrent(publishedDataId),
+                () => dmmPins.ReadAndPublish(maximumTimeInMilliseconds: 2000, publishedDataId));
+        }
+
+        internal static void SimplerMeasureAndPublishCurrentSmuOrPpmuOrDmm(ISemiconductorModuleContext tsmContext, string[] pinNames)
+        {
+            var sessionManager = new TSMSessionManager(tsmContext);
+            var publishedDataId = "Measurement";
+            // Note the filterPins parameter was introduced in the 24.5.1 release.
+            var smuPins = sessionManager.DCPower(pinNames, filterPins: true);
+            var ppmuPins = sessionManager.Digital(pinNames, filterPins: true);
+            var dmmPins = sessionManager.DMM(pinNames, filterPins: true);
+
+            // Just an example of the InvokeInParallel method, assumes that the instrumentation is already configured.
+            // Also, note that the null-conditional operator (?.) allows for the operation to be skipped when the SessionBundle object is null,
+            // which is the case when no pins of that instrument type are passed into the function when using the filterPins parameter.
+            Utilities.InvokeInParallel(
+                () => ppmuPins?.MeasureAndPublishCurrent(publishedDataId),
+                () => smuPins?.MeasureAndPublishCurrent(publishedDataId),
+                () => dmmPins?.ReadAndPublish(maximumTimeInMilliseconds: 2000, publishedDataId));
         }
     }
 }

--- a/docs/UserGuide/advanced/ConcurrentCodeExecution.md
+++ b/docs/UserGuide/advanced/ConcurrentCodeExecution.md
@@ -15,22 +15,18 @@ The following example demonstrates how to use the `InvokeInParallel` method from
 public static void ConcurrentCodeExample(ISemiconductorModuleContext semiconductorModuleContext, string pinNames)
 {
     var sessionManager = new TSMSessionManager(semiconductorModuleContext);
-    var publishDataID = "Measurement";
-    var filteredPinNamesDmm = semiconductorModuleContext.FilterPinsByInstrumentType(pinNames, InstrumentTypeIdConstants.NIDmm);
-    var filteredPinNamesPpmu = semiconductorModuleContext.FilterPinsByInstrumentType(pinNames, InstrumentTypeIdConstants.NIDigitalPattern);
+    var publishedDataId = "Measurement";
     var filteredPinNamesSmu = semiconductorModuleContext.FilterPinsByInstrumentType(pinNames, InstrumentTypeIdConstants.NIDCPower);
-    var ppmuPins = sessionManager.DCPower(filteredPinNamesSmu);
-    var smuPins = sessionManager.Digital(filteredPinNamesPpmu);
+    var filteredPinNamesPpmu = semiconductorModuleContext.FilterPinsByInstrumentType(pinNames, InstrumentTypeIdConstants.NIDigitalPattern);
+    var filteredPinNamesDmm = semiconductorModuleContext.FilterPinsByInstrumentType(pinNames, InstrumentTypeIdConstants.NIDmm);
+    var smuPins = sessionManager.DCPower(filteredPinNamesSmu);
+    var ppmuPins = sessionManager.Digital(filteredPinNamesPpmu);
     var dmmPins = sessionManager.DMM(filteredPinNamesPpmu);
 
     // Assumes that the instrumentation is already configured.
     Utilities.InvokeInParallel(
-        () => ppmuPins.MeasureAndPublishCurrent(publishDataID),
-        () => smuPins.MeasureAndPublishCurrent(publishDataID),
-        () =>
-        {
-            var measurements = dmmPins.Read(maximumTimeInMilliseconds: 2000);
-            semiconductorModuleContext.PublishResults(measurements, publishDataID);
-        });
+        () => ppmuPins.MeasureAndPublishCurrent(publishedDataId),
+        () => smuPins.MeasureAndPublishCurrent(publishedDataId),
+        () => dmmPins.ReadAndPublish(maximumTimeInMilliseconds: 2000, publishedDataId));
 }
 ```


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes the example code in the ConcurrentCodeExecution.md user guide topic and similarly the implementation in the actual MeasureVoltageMixed.cs example code. Also, it adds a new `SimplerMeasureAndPublishCurrentSmuOrPpmuOrDmm` example method to the MeasureVoltageMixed.cs that highlights the new filterPins parameter added to the TSMSessionManager members, which was introduced in the 24.5.1 release. Note that this is intentionally added as a separate example to leave the existing `SimpleMeasureAndPublishCurrentSmuOrPpmuOrDmm` example as is for 24.5.0 users (although it was intentionally renamed to add OrDmm at the end of the method name since it includes a DMM measure in the implementation).

### Why should this Pull Request be merged?

The current example code in the ConcurrentCodeExecution.md user guide topic and the similar implementation in the MeasureVoltageMixed.cs example code, has an incorrect

### What testing has been done?

Manually tested the example code to ensure it is working as intended.
