### PR TITLE
[WriterReviewNeeded] Make VerifyTaskType public

### DIFF
--- a/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/DAQmx/Utilities.cs
+++ b/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/DAQmx/Utilities.cs
@@ -4,8 +4,17 @@ using NationalInstruments.SemiconductorTestLibrary.Common;
 
 namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DAQmx
 {
-    internal static class Utilities
+    /// <summary>
+    /// Provides utility methods for NI DAQmx instrument abstraction.
+    /// </summary>
+    public static class Utilities
     {
+        /// <summary>
+        /// Verifies whether an NI DAQmx task is of a specific type.
+        /// </summary>
+        /// <param name="taskInformation">The task to check.</param>
+        /// <param name="expectedTaskType">The expected task type.</param>
+        /// <exception cref="NISemiconductorTestException">Thrown when the NI DAQmx task is not the specific type.</exception>
         public static void VerifyTaskType(this DAQmxTaskInformation taskInformation, DAQmxTaskType expectedTaskType)
         {
             if (!taskInformation.TaskType.Equals(expectedTaskType))
@@ -14,7 +23,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DAQ
             }
         }
 
-        public static bool HasSingleChannel(this ICollection channels)
+        internal static bool HasSingleChannel(this ICollection channels)
         {
             return channels.Count == 1;
         }


### PR DESCRIPTION
### What does this Pull Request accomplish?

Make the `VerifyTaskType` utility method public so that clients can make use of it.

### Why should this Pull Request be merged?

Making the method public enables reusability.

### What testing has been done?

N/A
