### PR TITLE
Fix Examples for Constructing PinSiteData/SiteData with Site-agnostic Data

### DIFF
--- a/Examples/source/DataAbstraction/PinSiteDataExamples.cs
+++ b/Examples/source/DataAbstraction/PinSiteDataExamples.cs
@@ -205,6 +205,23 @@ namespace NationalInstruments.SemiconductorTestLibrary.Examples.DataAbstraction
             var pinSiteData = new PinSiteData<double>(siteNumbers, perPinData);
         }
 
+        internal static void ConstructWithPinDataDictionaryAndSiteNumbersArrayWithSystemPin()
+        {
+            // Site numbers to associate with the data.
+            var siteNumbers = new int[] { 2, 4, 3, 1 };
+            // Dictionaries containing pin-unique data.
+            // Two separate dictionaries are used to delineate between DUT pins from System pin data.
+            var perDutPinData = new Dictionary<string, double> { ["VDET"] = 22, ["VCC1"] = 44, ["VCC2"] = 33 };
+            var perSystemPinSiteData = new Dictionary<string, double> { ["SystemSupply"] = -15 };
+            // First, construct a PinSiteData object with the DUT pin specific data dictionary and the siteNumbers array.
+            // Then, combine it with a new PinSiteData object constructed for the system pin specific data dictionary,
+            // where the siteNumbers input is an array containing a single element value of -1.
+            // Note that data associated with system pins is considered site-agnostic,
+            // and site-agnostic data can represented with -1 as the site value.
+            var pinSiteData = new PinSiteData<double>(siteNumbers, perDutPinData)
+                .Combine(new PinSiteData<double>(new[] { -1 }, perSystemPinSiteData));
+        }
+
         internal static void ConstructWithArraysForCommonDataValue()
         {
             // Site numbers to associate with the data.

--- a/Examples/source/DataAbstraction/PinSiteDataExamples.cs
+++ b/Examples/source/DataAbstraction/PinSiteDataExamples.cs
@@ -160,24 +160,47 @@ namespace NationalInstruments.SemiconductorTestLibrary.Examples.DataAbstraction
             var pinSiteData = new PinSiteData<double>(pinNames, perPinSiteData);
         }
 
+        internal static void ConstructWithArraysWithSystemPin()
+        {
+            // Pin names to associate with the data.
+            var pinNames = new string[] { "VCC1", "VCC2", "SystemSupply" };
+            // Site numbers to associate with the data.
+            var siteNumbers = new int[] { 0, 1 };
+            // Per-pin SiteData objects.
+            // Note that data associated with system pins is considered site-agnostic,
+            // and site-agnostic data can represented with -1 as the site value.
+            var perPinSiteData = new[]
+            {
+                new SiteData<double>(siteNumbers, 1.5),
+                new SiteData<double>(siteNumbers, 2.5),
+                new SiteData<double>(new[] { -1 }, -22.5)
+            };
+            // Constructs a PinSiteData object with pin names and associated SiteData object array,
+            // inclusive of system pin data.
+            var pinSiteData = new PinSiteData<double>(pinNames, perPinSiteData);
+        }
+
         internal static void ConstructWithDictionaryWithSystemPin()
         {
-            // Dictionary containing pin- and site-unique data.
+            // Dictionary containing pin- and site-unique data, including system pin data.
+            // Note that data associated with system pins is considered site-agnostic,
+            // and site-agnostic data can represented with -1 as the site value.
             var pinAndSiteUnqiueDataDictionary = new Dictionary<string, IDictionary<int, double>>
             {
-                ["VCC1"] = new Dictionary<int, double> { [0] = 1.5, [1] = 11.5, [-1] = -11.5 },
-                ["VCC2"] = new Dictionary<int, double> { [0] = 2.5, [1] = 22.5, [-1] = -22.5 }
+                ["VCC1"] = new Dictionary<int, double> { [0] = 1.5, [1] = 11.5 },
+                ["SystemSupply"] = new Dictionary<int, double> { [-1] = -22.5 }
             };
-            // Constructs a PinSiteData object with pin and site unique data dictionary.
+            // Constructs a PinSiteData object with pin and site unique data dictionary,
+            // inclusive of system pin data.
             var pinSiteData = new PinSiteData<double>(pinAndSiteUnqiueDataDictionary);
         }
 
         internal static void ConstructWithPinDataDictionaryAndSiteNumbersArray()
         {
             // Site numbers to associate with the data.
-            var siteNumbers = new int[] { 2, 4, 3, -1 };
+            var siteNumbers = new int[] { 2, 4, 3, 1 };
             // Dictionary containing pin-unique data.
-            var perPinData = new Dictionary<string, double> { ["VDET"] = 22, ["VCC1"] = 44, ["VCC2"] = 33, ["SystemSupply"] = -15 };
+            var perPinData = new Dictionary<string, double> { ["VDET"] = 22, ["VCC1"] = 44, ["VCC2"] = 33 };
             // Constructs a PinSiteData object with a pin specific data dictionary and siteNumbers array.
             var pinSiteData = new PinSiteData<double>(siteNumbers, perPinData);
         }

--- a/Examples/source/DataAbstraction/SiteDataExamples.cs
+++ b/Examples/source/DataAbstraction/SiteDataExamples.cs
@@ -139,9 +139,11 @@ namespace NationalInstruments.SemiconductorTestLibrary.Examples.DataAbstraction
             var perSiteDataDictionary = new Dictionary<int, double> { [1] = 11, [2] = 22, [3] = 33 };
             var siteData = new SiteData<double>(perSiteDataDictionary);
         }
-        internal static void ConstructWithDictionaryContainsSystemPin()
+        internal static void ConstructWithDictionaryWithSystemData()
         {
-            // Constructs a SiteData object with a dictionary of site unique data values, inclusive of a system pin
+            // Constructs a SiteData object with a dictionary of site unique data values,
+            // inclusive of a site-agnostic data,such as that associated with a system resource or pin.
+            // Note there can only be one site-agnostic value represented in a SiteData object.
             var perSiteDataDictionary = new Dictionary<int, double> { [1] = 11, [2] = 22, [-1] = 33 };
             var siteData = new SiteData<double>(perSiteDataDictionary);
         }


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes the examples for constructing PinSiteData and SiteData with site-agnostic data (i.e. System pins). 

### Why should this Pull Request be merged?

The current implementations are incorrect and are misleading to users.

### What testing has been done?

Manually created ad-hoc unit tests (not committed) to run the code as-is to confirm no errors, and the constructed data was structured as expected.
