### PR TITLE
Remove Dependency on Restricted Namespace from Examples

### DIFF
--- a/Examples/source/PatternTriggeredInstrumentControl/PatternTriggeredDmmMeasurement.cs
+++ b/Examples/source/PatternTriggeredInstrumentControl/PatternTriggeredDmmMeasurement.cs
@@ -5,7 +5,6 @@ using Ivi.Visa;
 using NationalInstruments.ModularInstruments.NIDigital;
 using NationalInstruments.ModularInstruments.NIDmm;
 using NationalInstruments.ModularInstruments.SystemServices.DeviceServices;
-using NationalInstruments.Restricted;
 using NationalInstruments.SemiconductorTestLibrary.Common;
 using NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction;
 using NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Digital;
@@ -157,7 +156,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.Examples
                 }
                 if (destinationDeviceResourceStrings.Contains(deviceInfo.Name))
                 {
-                    var index = destinationDeviceResourceStrings.IndexOf(deviceInfo.Name);
+                    int index = Array.IndexOf(destinationDeviceResourceStrings, deviceInfo.Name);
                     destinationChassisNumbers[index] = deviceInfo.ChassisNumber;
                     destinationSegments[index] = GetChassisSegment(deviceInfo.SlotNumber);
                 }


### PR DESCRIPTION
### What does this Pull Request accomplish?

Removes the dependency on the `NationalInstruments.Restricted` namespace by updating the `GetDeviceInfo` private method implementation in the `PatternTriggeredDmmMeasurement` example to use the native `System.Array.IndexOf` method.

### Why should this Pull Request be merged?

Ensure that public code is not using the `NationalInstruments.Restricted` namespace.

### What testing has been done?
Verified that all code builds without error. No additional testing was done as the `System.Array.IndexOf` method is functionally equivalent to the `NationalInstruments.Restricted.EnumerableExtensions.IndexOf`.
