### PR TITLE
Update FetchMeasurement DCPower Extension Method to Correctly Return Both Voltage and Current Results

### DIFF
--- a/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/DCPower/Measure.cs
+++ b/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/DCPower/Measure.cs
@@ -410,7 +410,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
                 var samples = new SingleDCPowerFetchResult[pointsToFetch];
                 for (int i = 0; i < pointsToFetch; i++)
                 {
-                    samples[i] = new SingleDCPowerFetchResult(measureResult.VoltageMeasurements[i], measureResult.VoltageMeasurements[i], measureResult.InCompliance[i]);
+                    samples[i] = new SingleDCPowerFetchResult(measureResult.VoltageMeasurements[i], measureResult.CurrentMeasurements[i], measureResult.InCompliance[i]);
                 }
                 return samples;
             });


### PR DESCRIPTION
### What does this Pull Request accomplish?

Updates the `DCPower.Measure.FetchMeasurement` Extension method to correctly return both voltage and current results. 

### Why should this Pull Request be merged?

The current `DCPower.Measure.FetchMeasurement` implementation returns the voltage measurement twice instead of including the current measurement. This causes users to see identical values for both voltage and current measurement.

### What testing has been done?

Auto tests are passing.
