### PR TITLE
Increase timeout for pr-intake to account peak dev times

### DIFF
--- a/.github/workflows/pr-intake.yml
+++ b/.github/workflows/pr-intake.yml
@@ -87,7 +87,7 @@ jobs:
         id: wait_build
         run: |
           SPECIFIC_BUILD_RUN_ID=${{ steps.get_build_runid.outputs.build_run_id }}
-          TIMEOUT=3600 # 1 hour
+          TIMEOUT=10800 # 3 hour
           INTERVAL=240 # 4 minutes
           ELAPSED=0
           while true; do
@@ -121,7 +121,7 @@ jobs:
         id: wait_test
         run: |
           SPECIFIC_TEST_RUN_ID=${{ steps.get_test_runid.outputs.test_run_id }}
-          TIMEOUT=3600 # 1 hour
+          TIMEOUT=10800 # 3 hour
           INTERVAL=240 # 4 minutes
           ELAPSED=0
           while true; do


### PR DESCRIPTION
### What does this Pull Request accomplish?

Recently NIBuild farm VMs have been pretty busy because of which pipeline runs need to wait for an agent to be available. So pr-intake timeout needs to be increased.

### Why should this Pull Request be merged?

Increases pr-intake timeout to 3 hours instead of 1 hour.

### What testing has been done?

NA
