### PR TITLE
[User Guide] Add STS Software Compatibility Table and Update NuGet Recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ You must have the following software to use the Semiconductor Test Library:
 
 Visual Studio 2022 is highly recommended.
 
+Refer to the [STS Software Version Compatibility](docs/UserGuide/Overview.md#sts-software-version-compatibility) table in user guide for more details.
+
 ## Documentation
 
 A complete set of documentation for the Semiconductor Test Library can be found here: [https://ni.github.io/semi-test-library-dotnet](https://ni.github.io/semi-test-library-dotnet)

--- a/docs/UserGuide/NuGetPackageManagementForSTSProjects.md
+++ b/docs/UserGuide/NuGetPackageManagementForSTSProjects.md
@@ -70,3 +70,10 @@ Use the following procedure to upgrade a dependent NuGet package that has alread
    > The NuGet package manager automatically recognizes an update to the target package and provides the option to upgrade. After you select Upgrade, the NuGet package manager will update PackageReference in .csproj.
 
 3. After you upgrade the package reference and successfully build your project against the newer version, remove the older version of the package (.nupkg) from your project's source files and commit the change to your source code control system.
+
+## Using STL Dependent 3rd-Party NuGet packages
+
+If there is a 3rd-party NuGet package you want to use within an STS project, which itself is dependent on the Semiconductor Test Library (STL), then the STS project must use the same version of STL that the 3rd party package was built with. Otherwise, the STS project may encounter a runtime error.
+
+>[!NOTE]
+> In all other instances, the STS project is free to target which ever version of the STL NuGet package that is compatible with the STS Software version being used. Refer to the compatibility table under [*STS Software Version Compatibility*](Overview.md/#sts-software-version-compatibility).

--- a/docs/UserGuide/Overview.md
+++ b/docs/UserGuide/Overview.md
@@ -70,3 +70,18 @@ Additionally, the `TestStandSteps` assembly is installed in the following TestSt
 
 >[!NOTE]
 > Refer to [Using TestStand Steps](UsingTestStandSteps.md) for more information.
+
+### STS Software Version Compatibility
+
+The following table highlights which release versions of Semiconductor Test Library (STL) are installed with which version of STS Software, and which version of the STL NuGet packages are supported when using a certain version of STS Software.
+
+| **STS Software Version** | **Installed STL Version** | **Compatible STL NuGet Version** |
+| ------ | ------ | ------------------------------ |
+| 24.5.0 | 24.5.0 | 24.5.0, 24.5.1, 24.5.2, 25.0.0 |
+| 24.5.1 | 24.5.1 | 24.5.0, 24.5.1, 24.5.2, 25.0.0 |
+| 24.5.2 | 24.5.1 | 24.5.0, 24.5.1, 24.5.2, 25.0.0 |
+
+> [!NOTE]
+> *Installed STL Version* - refers to the release version of STL assemblies that are installed by STS Software into the following directory: `C:\Program Files\National Instruments\Shared\NI_SemiconductorTestLibrary`.
+>
+> *Compatible STL NuGet Version* - refers to the version of the STL NuGet package that can be used and referenced by your test program project.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,8 @@ You must have the following software to use the Semiconductor Test Library:
 
 Visual Studio 2022 is highly recommended.
 
+Refer to the [STS Software Version Compatibility](UserGuide/Overview.md#sts-software-version-compatibility) table more details.
+
 ## Getting Started
 
 To get started, use the STS Project Creation Tool included with STS Software 24.5 (or later) to create a new test program using the NI Default - C#/.NET template. The template program includes and references a copy of the NationalInstruments.SemiconductorTestLibrary NuGet package. NI recommends using this template test program as a starting point to use the Semiconductor Test Library in new projects.


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adds STS Software Compatibility Table and Update NuGet Recommendations, specifically:
- Adds _STS Software Version Compatibility_ section to the _Overview_ topic in the user guide.
- Adds _Using STL Dependent 3rd-Party NuGet Packages_ subsection to the _NuGet Package Management for STS Projects_ topic in the user guide.
- Updates the user guide landing page (index) to mention new  _STS Software Version Compatibility_ table.
- Updates GitHub repo's README.md to mention new  _STS Software Version Compatibility_ table.

### Why should this Pull Request be merged?

Some users reported encountering an error when developing with a 3rd-Party NuGet Package that was also dependent on STL. This updated recommendation is intended to provide guidance for any user encountering this situation. In parallel, the same users also provided feedback that it would be helpful to have a compatibility table to highlight which versions of the STL NuGet packages are supported when using a certain version of STS Software.

### What testing has been done?

Manually built and served the docfx site locally on my development system, validating the page rendered with the correct format and all links were working as expected.
