### PR TITLE
Update auto-comment-fixed-issues.yml Workflow: Add Conditional Branch Filter

### DIFF
--- a/.github/workflows/auto-comment-fixed-issues.yml
+++ b/.github/workflows/auto-comment-fixed-issues.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   comment-on-issues:
+    if: startsWith(github.ref, 'refs/heads/releases/')
     runs-on: ubuntu-latest
     steps:
       - name: Process issues for new release


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Adds a conditional check to the job execution.
`if: startsWith(github.ref, 'refs/heads/releases/')` 
- Ensures the comment-on-issues job only runs when a branch is created under the releases/ namespace.
- Prevents unnecessary execution of the job for non-release branches.

### Why should this Pull Request be merged?

- Increases the reliability and precision of the workflow.
- Ensures that jobs only run in valid release branch contexts, maintaining clarity and control over automation behavior.

### What testing has been done?

- Verified that the workflow still runs correctly on branches matching releases/*.
- Confirmed that the job is skipped for non-release branches using the new if condition.
- Ensured no changes to the logic for searching issues or posting comments, preserving existing functionality.