### PR TITLE
Updated gh-pages-deploy workflow to use docfx-2.77

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -36,7 +36,8 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.x
-      - run: dotnet tool update -g docfx
+      - name: Install docfx 2.77
+        run: dotnet tool install -g docfx --version 2.77
       - run: docfx build docs/docfx.json
       - run: docfx pdf docs/docfx.json
       - name: Upload artifact


### PR DESCRIPTION
### What does this Pull Request accomplish?

This PR forces the gh-pages-deploy workflow to use docfx v2.77 instead of the current latest v2.78.

### Why should this Pull Request be merged?

As mentioned in the below PR, we observed some breaking changes if using docfx v2.78. So docfx version needs to be forced to older version 2.77 in the gh-pages-deploy workflow.
https://github.com/ni/semi-test-library-dotnet/pull/232

### What testing has been done?
NA
