### PR TITLE
PR workflow improvement

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -19,6 +19,21 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@v2
+
+        - name: Check triggering workflow status
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          run: |
+            RUN_ID=${{ github.event.workflow_run.id }}
+            REPO=${{ github.repository }}
+            STATUS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+              "https://api.github.com/repos/$REPO/actions/runs/$RUN_ID" | jq -r '.conclusion')
+            echo "Triggering workflow conclusion: $STATUS"
+            if [[ "$STATUS" == "failure" || "$STATUS" == "cancelled" ]]; then
+              echo "Triggering workflow failed or was cancelled. Exiting."
+              exit 1
+            fi
+
         - name: Trigger Azure Pipeline for Pre Build
           uses: enfa/azure-pipeline-github-action@v1.0.0
           with:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -19,6 +19,21 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@v2
+
+        - name: Check triggering workflow status
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          run: |
+            RUN_ID=${{ github.event.workflow_run.id }}
+            REPO=${{ github.repository }}
+            STATUS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+              "https://api.github.com/repos/$REPO/actions/runs/$RUN_ID" | jq -r '.conclusion')
+            echo "Triggering workflow conclusion: $STATUS"
+            if [[ "$STATUS" == "failure" || "$STATUS" == "cancelled" ]]; then
+              echo "Triggering workflow failed or was cancelled. Exiting."
+              exit 1
+            fi
+
         - name: Trigger Azure Pipeline for Unit Test
           uses: enfa/azure-pipeline-github-action@v1.0.0
           with:


### PR DESCRIPTION
### What does this Pull Request accomplish?

This PR adds an extra level of validation before calling the AzDo pipelines from GitHub workflows.

### Why should this Pull Request be merged?

Recently I observed an issue where if a pr-intake workflow is not approved for 30 days, GitHub automatically cancels that workflow but even then the pr-build and pr-test get triggered sometimes.
To ensure the AzDo pipeline only triggers when the pr-intake workflow is approved, I added a level of validation in the pr-build and pr-test workflow. Now these workflows will check if the workflow triggering them, i.e., pr-intake should not be canceled or failed, if not then only it will call the AzDo pipeline or else exit safely.

### What testing has been done?

I tested the workflow run in my forked repo. Final testing in this repo will be done once this PR merges in the main.
