### PR TITLE
Fix LeakageTest

### DIFF
--- a/SemiconductorTestLibrary.TestStandSteps/source/LeakageTest.cs
+++ b/SemiconductorTestLibrary.TestStandSteps/source/LeakageTest.cs
@@ -102,7 +102,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.TestStandSteps
                         {
                             var dcPowerPerPinOrPinGroup = sessionManager.DCPower(dcPowerPins);
                             dcPowerPerPinOrPinGroup.ForceVoltage(voltageLevel, waitForSourceCompletion: true);
-                            dcPowerPerPinOrPinGroup.MeasureAndPublishVoltage("Leakage", out _);
+                            dcPowerPerPinOrPinGroup.MeasureAndPublishCurrent("Leakage", out _);
                             dcPowerPerPinOrPinGroup.ForceVoltage(0, waitForSourceCompletion: true);
                         }
 
@@ -111,7 +111,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.TestStandSteps
                         {
                             var digitalPerPinOrPinGroup = sessionManager.Digital(digitalPins);
                             digitalPerPinOrPinGroup.ForceVoltage(voltageLevel, settlingTime: settlingTime);
-                            digitalPerPinOrPinGroup.MeasureAndPublishVoltage("Leakage", out _);
+                            digitalPerPinOrPinGroup.MeasureAndPublishCurrent("Leakage", out _);
                             digitalPerPinOrPinGroup.ForceVoltage(0, settlingTime: settlingTime);
                         }
                     }


### PR DESCRIPTION
### What does this Pull Request accomplish?

There is a mistake in `LeakageTest` that when serial operation is enabled, we currently is calling `MeasureAndPublishVoltage` while it should be `MeasureAndPublishCurrent`. This pull request corrects the mistake.

### Why should this Pull Request be merged?

To fix an existing mistake.

### What testing has been done?

N/A. Will enhance existing test suite so that it's able to catch this kind of mistakes before code submission.
