### PR TITLE
Removed gated environment from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
     build:
         name: Call Azure Pipeline
         runs-on: ubuntu-latest
-        environment: gh-action-testing
         steps:
         - uses: actions/checkout@v2        
         - uses: enfa/azure-pipeline-github-action@v1.0.0


### PR DESCRIPTION
### What does this Pull Request accomplish?

This PR removes the gated environment from CI workflow. This workflow triggers automatically only when any PR completes. 
[Technical Debt 2938880](https://dev.azure.com/ni/DevCentral/_workitems/edit/2938880): [Minor] Remove environment from GitHub CI workflow so that it runs automatically without approval

### Why should this Pull Request be merged?

Currently, the GitHub CI workflow needs approval to run because it has an environment set. This can be removed as we have a pr-intake workflow that already has this environment and once PR is merged, no need to separately approve the CI run. Removing the need for approval here will faster the development process.

### What testing has been done?

NA