### PR TITLE
Adding pin map with invalid pin connection for merge cascade configuration

### DIFF
--- a/TestAssets/Supporting Materials/Pin Maps/MergedPinGroupTest_InvalidConnectionForMergeConfiguration.pinmap
+++ b/TestAssets/Supporting Materials/Pin Maps/MergedPinGroupTest_InvalidConnectionForMergeConfiguration.pinmap
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<PinMap schemaVersion="1.6" xmlns="http://www.ni.com/TestStand/SemiconductorModule/PinMap.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<Instruments>
+		<NIDCPowerInstrument name="SMU_4147_C1_S11" numberOfChannels="4">
+			<ChannelGroup name="SMU_4147_C1_S11_CH0" channels="0" />
+			<ChannelGroup name="SMU_4147_C1_S11_CH1" channels="1" />
+			<ChannelGroup name="SMU_4147_C1_S11_CH2" channels="2" />
+			<ChannelGroup name="SMU_4147_C1_S11_CH3" channels="3" />
+		</NIDCPowerInstrument>
+		<NIDCPowerInstrument name="SMU_4147_C2_S10" numberOfChannels="4">
+			<ChannelGroup name="SMU_4147_C2_S10_CH0" channels="0" />
+			<ChannelGroup name="SMU_4147_C2_S10_CH1" channels="1" />
+			<ChannelGroup name="SMU_4147_C2_S10_CH2" channels="2" />
+			<ChannelGroup name="SMU_4147_C2_S10_CH3" channels="3" />
+		</NIDCPowerInstrument>
+	</Instruments>
+	<Pins>
+		<DUTPin name="VCCPrimary" />
+		<DUTPin name="VCCSecondary" />
+		<DUTPin name="VDDPrimary" />
+		<DUTPin name="VDDSecondary" />
+	</Pins>
+	<PinGroups>
+		<PinGroup name="AllPinsMergedGroupWithVCCPrimaryAsPrimaryPin">
+			<PinReference pin="VCCPrimary" />
+			<PinReference pin="VCCSecondary" />
+			<PinReference pin="VDDPrimary" />
+			<PinReference pin="VDDSecondary" />
+		</PinGroup>
+		<PinGroup name="PinsConnectedToDifferentInstruments">
+			<!--Group having primary and secondary pin connected to different instruments, where VCCPrimary is primary pin-->
+			<PinReference pin="VCCPrimary" />
+			<PinReference pin="VCCSecondary" />
+		</PinGroup>
+		<PinGroup name="PinsConnectedToNonConsecutiveChannels">
+			<!--Pins connected to non consecutive channels-->
+			<PinReference pin="VCCPrimary" />
+			<PinReference pin="VDDPrimary" />
+		</PinGroup>
+	</PinGroups>
+	<Sites>
+		<Site siteNumber="0" />
+		<Site siteNumber="1" />
+	</Sites>
+	<Connections>
+		<Connection pin="VCCPrimary" siteNumber="0" instrument="SMU_4147_C1_S11" channel="0" />
+		<Connection pin="VCCSecondary" siteNumber="0" instrument="SMU_4147_C2_S10" channel="1" />
+		<Connection pin="VDDPrimary" siteNumber="0" instrument="SMU_4147_C1_S11" channel="2" />
+		<Connection pin="VDDPrimary" siteNumber="1" instrument="SMU_4147_C2_S10" channel="2" />
+		<Connection pin="VDDSecondary" siteNumber="0" instrument="SMU_4147_C1_S11" channel="3" />
+		<Connection pin="VDDSecondary" siteNumber="1" instrument="SMU_4147_C2_S10" channel="3" />
+		<Connection pin="VCCPrimary" siteNumber="1" instrument="SMU_4147_C2_S10" channel="0" />
+		<Connection pin="VCCSecondary" siteNumber="1" instrument="SMU_4147_C1_S11" channel="1" />
+	</Connections>
+</PinMap>


### PR DESCRIPTION
### What does this Pull Request accomplish?

This PR adds `MergedPinGroupTest_InvalidConnectionForMergeConfiguration.pinmap`  for testing of invalid scenarios for merge cascade feature and it contains following group scenarios:
1. `PinsConnectedToDifferentInstruments` :  Group having primary and secondary pin connected to different instruments, where `VCCPrimary` is primary pin. 
2. `PinsConnectedToNonConsecutiveChannels`: Pins connected to non consecutive channels with `VCCPrimary` as primary pin.

### Why should this Pull Request be merged?

Added `.pinmap` files with t test invalid  Merge Group configuration under `TestAssets/Supporting Materials/Pin Maps` folder.

### What testing has been done?

N/A
