### PR TITLE
Adding ChiXiao to HardwareConfiguration enum

### DIFF
--- a/TestAssets/Tests.SemiconductorTestLibrary.Utilities/TestFilters.cs
+++ b/TestAssets/Tests.SemiconductorTestLibrary.Utilities/TestFilters.cs
@@ -3,7 +3,8 @@
     public enum HardwareConfiguration
     {
         GP3,
-        Lungyuan
+        Lungyuan,
+        ChiXiao
     }
 
     public enum Platform


### PR DESCRIPTION
### What does this Pull Request accomplish?
This PR adds ChiXiao to HardwareConfiguration enum.

### Why should this Pull Request be merged?
This PR adds ChiXiao to HardwareConfiguration enum, which is required to run the validation auto test for SMU4147(as this module is not present in Lungyuan)

### What testing has been done?

N/A
