### PR TITLE
[DOCUMENTATION] Update Supported Instrument Doc with 4309/10 and Custom Instrument Support

### DIFF
--- a/docs/UserGuide/SupportedInstrumentTypes.md
+++ b/docs/UserGuide/SupportedInstrumentTypes.md
@@ -1,6 +1,10 @@
 # Supported Instrument Types
 
-The Semiconductor Test Library supports the core set of modular instruments commonly used within the NI [Semiconductor Test System (STS)](https://www.ni.com/sts). Refer to the following table for the instrument types currently supported by the library.
+The Semiconductor Test Library supports the core set of modular instruments commonly used within the NI [Semiconductor Test System (STS)](https://www.ni.com/sts).
+
+If an instrument type is not listed in the table below, proceed with low-level instrument channel centric programming for the desired instrument type in your test code. This will involve using the [Custom Instrument Support](***TODO: Link will be given once Naga's PR is merged***) to program your own Extension and TeststandStep methods to control the desired instrument. Contact NI support if you need any assistance with this.
+
+Refer to the following table for the instrument types currently supported by the library.
 
 **Table 1:** Supported Instrument Types
 
@@ -39,5 +43,3 @@ The Semiconductor Test Library supports the core set of modular instruments comm
 
 > [!TIP]
 > When Extensions are not supported by an instrument type, but Abstractions support is provided, you can refer to the [Making Low-Level Driver Calls](advanced/MakingLowLevelDriverCalls.md) topic to learn how to interact with the low-level driver APIs at the Abstractions layer.
->
-> If an instrument type is not listed in the table above, proceed with low-level instrument channel centric programming for the desired instrument type in your test code. This will involve using the [TestStand Semiconductor Module Code Module API](https://www.ni.com/docs/en-US/bundle/teststand-semiconductor-module/page/tsm-code-module-api.html) to query instruments and pin-to-channel mappings from the pin map, in combination with the appropriate driver API to control the desired instrument. Contact NI support if you need any assistance with this.

--- a/docs/UserGuide/SupportedInstrumentTypes.md
+++ b/docs/UserGuide/SupportedInstrumentTypes.md
@@ -8,8 +8,9 @@ The Semiconductor Test Library supports the core set of modular instruments comm
 | :--------------------------------------   | :-------- | :----------- | :------------------- |
 | NI Source Measurement Unit (SMU)          | niDCPower | :heavy_check_mark: | :heavy_check_mark: |
 | NI Programmable Power Supply (PPS)        | niDCPower | :heavy_check_mark: | :heavy_check_mark: |
-| NI Multifunction I/O (DAQ) \*             | niDAQmx   | :warning: | :warning:   |
+| NI Multifunction I/O (DAQ) \*             | niDAQmx   | :warning: | :warning: |
 | NI Sound and Vibration Module (DSA) \* \* | niDAQmx   | :warning: | :warning: |
+| NI Analog Input Module (DAQ) \* \* \*     | niDAQmx   | :warning: | :warning: |
 | NI Digital Pattern Instrument (DPI/HSD)   | niDigital | :heavy_check_mark: | :heavy_check_mark: |
 | NI Digital Multimeter (DMM)               | niDmm     | :heavy_check_mark: | :heavy_check_mark: |
 | NI Relay Module (RELAY)                   | niSwitch  | :heavy_check_mark: | :heavy_check_mark: |
@@ -31,6 +32,10 @@ The Semiconductor Test Library supports the core set of modular instruments comm
 > \* \* \
 > Supported Devices: PXIe-4467/8 \
 > Supported Functionality: Analog Input, Analog Output, Analog Output: Function Generation
+>
+> \* \* \* \
+> Supported Devices: PXIe-4309/10 \
+> Supported Functionality: Analog Input
 
 > [!TIP]
 > When Extensions are not supported by an instrument type, but Abstractions support is provided, you can refer to the [Making Low-Level Driver Calls](advanced/MakingLowLevelDriverCalls.md) topic to learn how to interact with the low-level driver APIs at the Abstractions layer.


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Added PXIe 4309 and 4310 in the Supported Instrument table, along with their supported functionality in the `Note`.
- Replaced TSM Code Module API Support with Custom Instrument Support.
- The Custom Instrument Support paragraph is removed from `Tip` and added above the Supported Instrument table.

### Why should this Pull Request be merged?

- We need to add PXIe 4309 and 4310 to the Supported Instrument table.
- Custom Instrument Support should be added and replaced with the TSM Code Module API Support.
- User Story: 

### What testing has been done?

- Checked on lint & markdown formatting. 
- Checked the formatting through preview.
