### PR TITLE
[User Manual] Correcting a typo in `PublishedDataId(s)` used by AcquireAnalogInputWaveforms TestStand Step

### DIFF
--- a/docs/UserGuide/UsingTestStandSteps.md
+++ b/docs/UserGuide/UsingTestStandSteps.md
@@ -34,7 +34,7 @@ The following table shows the Published Data Ids for the TestStandSteps provided
 | Method Name                            | PublishedDataId(s)       | Data Type | Units                  |
 | :------------------------------------- | :----------------------- | :-------- | :--------------------- |
 | `AcquireAnalogInputWaveforms`          | Minimum                  | Numeric   | \*Depends on task type |
-|                                        | Minimum                  | Numeric   | \*Depends on task type |
+|                                        | Maximum                  | Numeric   | \*Depends on task type |
 | `BurstPattern`                         | Pattern Pass/Fail Result | Boolean   | N/A                    |
 |                                        | Pattern Fail Count       | Numeric   | N/A                    |
 | `ContinuityTest`                       | Continuity               | Numeric   | Volts                  |


### PR DESCRIPTION
### What does this Pull Request accomplish?

Replaced duplicate entry with 'Maximum' publish tag.

### Why should this Pull Request be merged?

Currently table contains duplicate entry for 'Minimum' publish tag. It is supposed to be 'Maximum'

### What testing has been done?
Ensured that `Maximum` tag is used by `AcquireAnalogInputWaveforms`, verified with integration tests written verify against `Maximum`
