### PR TITLE
[Rjected][POC2] Introducing deprecated overload methods to fix TestStand step warnings using deprecated namespace.

### DIFF
--- a/SemiconductorTestLibrary.TestStandSteps/source/DeprecatedSetupNIDigitalPatternInstrumentation.cs
+++ b/SemiconductorTestLibrary.TestStandSteps/source/DeprecatedSetupNIDigitalPatternInstrumentation.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.ComponentModel;
+using NationalInstruments.TestStand.SemiconductorModule.CodeModuleAPI;
+
+namespace NationalInstruments.SemiconductorTestLibrary.TestStandStepsDeprecated
+{
+    /// <summary>
+    /// [Deprecated] SetupAndCleanupSteps class.
+    /// </summary>
+    public static partial class SetupAndCleanupSteps
+    {
+        /// <summary>
+        /// [Deprecated] This method is deprecated and use the other overload instead.
+        /// </summary>
+        /// <param name="tsmContext">The <see cref="ISemiconductorModuleContext"/> object.</param>
+        /// <param name="resetDevice">Whether to reset device during initialization.</param>
+        /// <param name="levelsSheetToApply">The name of the levels sheet to apply.</param>
+        /// <param name="timingSheetToApply">The name of the timing sheet to apply.</param>
+        [Obsolete("Use TestStandSteps.NIInstrumentType instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void SetupNIDigitalPatternInstrumentation(
+            ISemiconductorModuleContext tsmContext,
+            bool resetDevice = false,
+            string levelsSheetToApply = "",
+            string timingSheetToApply = "")
+        {
+            TestStandSteps.SetupAndCleanupSteps.SetupNIDigitalPatternInstrumentation(
+            tsmContext,
+            resetDevice,
+            levelsSheetToApply,
+            timingSheetToApply,
+            false);
+        }
+    }
+}

--- a/SemiconductorTestLibrary.TestStandSteps/source/Deprecated_CleanupInstrumentation.cs
+++ b/SemiconductorTestLibrary.TestStandSteps/source/Deprecated_CleanupInstrumentation.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.ComponentModel;
+using NationalInstruments.TestStand.SemiconductorModule.CodeModuleAPI;
+
+namespace NationalInstruments.SemiconductorTestLibrary.TestStandStepsDeprecated
+{
+    /// <summary>
+    /// [Deprecated]SetupAndCleanupSteps.
+    /// </summary>
+    public static partial class SetupAndCleanupSteps
+    {
+        /// <summary>
+        /// [Deprecated]NIInstrumentType.
+        /// </summary>
+        public enum NIInstrumentType
+        {
+            /// <summary>
+            /// All NI instruments.
+            /// </summary>
+            All,
+
+            /// <summary>
+            /// An NI-DCPower instrument.
+            /// </summary>
+            NIDCPower,
+
+            /// <summary>
+            /// An NI-Digital Pattern instrument.
+            /// </summary>
+            NIDigitalPattern,
+
+            /// <summary>
+            /// A relay driver module (NI-SWITCH instrument).
+            /// </summary>
+            NIRelayDriver,
+
+            /// <summary>
+            /// An NI-DAQmx task.
+            /// </summary>
+            NIDAQmx,
+
+            /// <summary>
+            /// An NI-DMM instrument.
+            /// </summary>
+            NIDMM,
+
+            /// <summary>
+            /// An NI-FGEN instrument.
+            /// </summary>
+            NIFGen,
+
+            /// <summary>
+            /// An NI-SCOPE instrument.
+            /// </summary>
+            NIScope,
+
+            /// <summary>
+            /// An NI-Sync instrument.
+            /// </summary>
+            NISync
+        }
+
+        /// <summary>
+        /// [Deprecated]CleanupInstrumentation.
+        /// </summary>
+        /// <param name="tsmContext">a</param>
+        /// <param name="resetDevice">a</param>
+        /// <param name="instrumentType">a</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("This overload is deprecated. Use the overload without optional parameter.", error: true)]
+        public static void CleanupInstrumentation(
+            ISemiconductorModuleContext tsmContext,
+            bool resetDevice = false,
+            NIInstrumentType instrumentType = NIInstrumentType.All)
+        {
+            TestStandSteps.SetupAndCleanupSteps.CleanupInstrumentation(
+            tsmContext,
+            resetDevice,
+            (TestStandSteps.NIInstrumentType)instrumentType);
+        }
+    }
+}


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adding back deprecated Enum and an overload method in a separate deprecated namespace.

### Why should this Pull Request be merged?

POC created for supporting forward compatibility in Test Stand for STL

The enum `NIInstrumentType` was defined earlier inside `SetupAndCleanupSteps` call. Now it is moved out of `SetupAndCleanupSteps`class. When a test sequence created in 24.5 STL is upgraded to >25.0 and above, this creates a warning against `CleanupInstrumentation` step. The Sequence runs fine but user has to update the prototype by clicking on the warning.

Re-Introducing the deprecated overload method will allow old Sequence load without warning. Since, deprecated method does call back to other overload, sequence also runs fine.

### What testing has been done?

TODO: Detail what testing has been done to ensure this submission meets requirements.