### PR TITLE
[SMU Gang Pin Group] - Splitting Force Method to be able to configure and initiate channels independently

### DIFF
--- a/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/DCPower/Source.cs
+++ b/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/DCPower/Source.cs
@@ -116,7 +116,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
                     LevelRange = voltageLevelRange,
                     LimitRange = currentLimitRange
                 };
-                sessionInfo.Force(settings, sitePinInfo.IndividualChannelString, waitForSourceCompletion);
+                sessionInfo.Force(settings, sitePinInfo, waitForSourceCompletion);
             });
         }
 
@@ -143,7 +143,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
                     LevelRange = voltageLevelRange,
                     LimitRange = currentLimitRange
                 };
-                sessionInfo.Force(settings, sitePinInfo.IndividualChannelString, waitForSourceCompletion);
+                sessionInfo.Force(settings, sitePinInfo, waitForSourceCompletion);
             });
         }
 
@@ -170,7 +170,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
                     LevelRange = voltageLevelRange,
                     LimitRange = currentLimitRange
                 };
-                sessionInfo.Force(settings, sitePinInfo.IndividualChannelString, waitForSourceCompletion);
+                sessionInfo.Force(settings, sitePinInfo, waitForSourceCompletion);
             });
         }
 
@@ -186,7 +186,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
             sessionsBundle.Do(sessionInfo =>
             {
                 settings.OutputFunction = DCPowerSourceOutputFunction.DCVoltage;
-                sessionInfo.Force(settings, sessionInfo.AllChannelsString, waitForSourceCompletion);
+                sessionInfo.Force(settings, waitForSourceCompletion: waitForSourceCompletion);
             });
         }
 
@@ -203,7 +203,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
             {
                 var perSiteSettings = settings.GetValue(sitePinInfo.SiteNumber);
                 perSiteSettings.OutputFunction = DCPowerSourceOutputFunction.DCVoltage;
-                sessionInfo.Force(perSiteSettings, sitePinInfo.IndividualChannelString, waitForSourceCompletion);
+                sessionInfo.Force(perSiteSettings, sitePinInfo, waitForSourceCompletion);
             });
         }
 
@@ -220,7 +220,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
             {
                 var perPinSettings = settings[sitePinInfo.PinName];
                 perPinSettings.OutputFunction = DCPowerSourceOutputFunction.DCVoltage;
-                sessionInfo.Force(perPinSettings, sitePinInfo.IndividualChannelString, waitForSourceCompletion);
+                sessionInfo.Force(perPinSettings, sitePinInfo, waitForSourceCompletion);
             });
         }
 
@@ -237,7 +237,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
             {
                 var perSitePinPairSettings = settings.GetValue(sitePinInfo);
                 perSitePinPairSettings.OutputFunction = DCPowerSourceOutputFunction.DCVoltage;
-                sessionInfo.Force(perSitePinPairSettings, sitePinInfo.IndividualChannelString, waitForSourceCompletion);
+                sessionInfo.Force(perSitePinPairSettings, sitePinInfo, waitForSourceCompletion);
             });
         }
 
@@ -320,7 +320,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
                     LevelRange = currentLevelRange,
                     LimitRange = voltageLimitRange
                 };
-                sessionInfo.Force(settings, sitePinInfo.IndividualChannelString, waitForSourceCompletion: waitForSourceCompletion);
+                sessionInfo.Force(settings, sitePinInfo, waitForSourceCompletion: waitForSourceCompletion);
             });
         }
 
@@ -347,7 +347,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
                     LevelRange = currentLevelRange,
                     LimitRange = voltageLimitRange
                 };
-                sessionInfo.Force(settings, sitePinInfo.IndividualChannelString, waitForSourceCompletion: waitForSourceCompletion);
+                sessionInfo.Force(settings, sitePinInfo, waitForSourceCompletion: waitForSourceCompletion);
             });
         }
 
@@ -374,7 +374,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
                     LevelRange = currentLevelRange,
                     LimitRange = voltageLimitRange
                 };
-                sessionInfo.Force(settings, sitePinInfo.IndividualChannelString, waitForSourceCompletion: waitForSourceCompletion);
+                sessionInfo.Force(settings, sitePinInfo, waitForSourceCompletion: waitForSourceCompletion);
             });
         }
 
@@ -390,7 +390,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
             sessionsBundle.Do(sessionInfo =>
             {
                 settings.OutputFunction = DCPowerSourceOutputFunction.DCCurrent;
-                sessionInfo.Force(settings, sessionInfo.AllChannelsString, waitForSourceCompletion);
+                sessionInfo.Force(settings, waitForSourceCompletion: waitForSourceCompletion);
             });
         }
 
@@ -407,7 +407,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
             {
                 var perSiteSettings = settings.GetValue(sitePinInfo.SiteNumber);
                 perSiteSettings.OutputFunction = DCPowerSourceOutputFunction.DCCurrent;
-                sessionInfo.Force(perSiteSettings, sitePinInfo.IndividualChannelString, waitForSourceCompletion);
+                sessionInfo.Force(perSiteSettings, sitePinInfo, waitForSourceCompletion);
             });
         }
 
@@ -424,7 +424,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
             {
                 var perPinSettings = settings[sitePinInfo.PinName];
                 perPinSettings.OutputFunction = DCPowerSourceOutputFunction.DCCurrent;
-                sessionInfo.Force(perPinSettings, sitePinInfo.IndividualChannelString, waitForSourceCompletion);
+                sessionInfo.Force(perPinSettings, sitePinInfo, waitForSourceCompletion);
             });
         }
 
@@ -441,7 +441,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
             {
                 var perSitePinPairSettings = settings.GetValue(sitePinInfo);
                 perSitePinPairSettings.OutputFunction = DCPowerSourceOutputFunction.DCCurrent;
-                sessionInfo.Force(perSitePinPairSettings, sitePinInfo.IndividualChannelString, waitForSourceCompletion);
+                sessionInfo.Force(perSitePinPairSettings, sitePinInfo, waitForSourceCompletion);
             });
         }
 
@@ -515,7 +515,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
                 };
                 // Applies limits and ranges.
                 var perChannelString = sitePinInfo.IndividualChannelString;
-                sessionInfo.Force(settings, perChannelString);
+                sessionInfo.Force(settings, sitePinInfo);
 
                 var channelOutput = sessionInfo.Session.Outputs[perChannelString];
                 channelOutput.Control.Abort();
@@ -935,11 +935,23 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
 
         #region private and internal methods
 
-        private static void Force(this DCPowerSessionInformation sessionInfo, DCPowerSourceSettings settings, string channelString = "", bool waitForSourceCompletion = false)
+        private static void Force(this DCPowerSessionInformation sessionInfo, DCPowerSourceSettings settings, SitePinInfo sitePinInfo = null, bool waitForSourceCompletion = false)
         {
-            var channelOutput = string.IsNullOrEmpty(channelString) ? sessionInfo.AllChannelsOutput : sessionInfo.Session.Outputs[channelString];
+            var channelString = sitePinInfo != null ? sitePinInfo.IndividualChannelString : sessionInfo.AllChannelsString;
+            var channelOutput = sessionInfo.Session.Outputs[channelString];
+            sessionInfo.ConfigureChannels(settings, channelOutput, channelString, sitePinInfo);
+            sessionInfo.InitiateChannels(channelOutput, waitForSourceCompletion);
+        }
+
+        private static void ConfigureChannels(this DCPowerSessionInformation sessionInfo, DCPowerSourceSettings settings, DCPowerOutput channelOutput, string channelString = "", SitePinInfo sitePinInfo = null)
+        {
             channelOutput.Control.Abort();
             sessionInfo.ConfigureSourceSettings(settings, channelString);
+            channelOutput.Control.Commit();
+        }
+
+        private static void InitiateChannels(this DCPowerSessionInformation sessionInfo, DCPowerOutput channelOutput, bool waitForSourceCompletion = false)
+        {
             channelOutput.Source.Output.Enabled = true;
             channelOutput.Control.Initiate();
             if (waitForSourceCompletion)


### PR DESCRIPTION
### What does this Pull Request accomplish?
This PR contains changes related to splitting of `Force` method into `ConfigureChannels` and `InitiateChannels` therby providing a way to just configure channels and later initiating it. 

### Why should this Pull Request be merged?
In order to gang channels, follower channels must be configured first and later be initiated while the leader channel is initiated. Hence configuring and initiating channels must be separated and should happen independently. For normal operations, `Force` method is directly called and hence there won't be any impact by this change.

As part of ganging implementation, `SitePinInfo` object which holds the ganging related properties through its `CascadingInfo` member needs to be accessed while configuring the channels with ganging related properties. Hence `Force` method's signature is changed to include `sitePinInfo` as optional argument. Optional parameter `channelString` is removed because channel string can be obtained from `sitePinInfo` itself.

So, when `Force` method is called with `sitePinInfo` as argument, forcing happens on the particular channel associated to that `sitePinInfo`. If not, all channels present in the session information are forced.

`ConfigureChannels` and `InitiateChannels` both take `channelOutput` as arguement. 
`ConfigureSourceSettings` method's signature will also be modified in upcoming PR to include `sitePinInfo` and `channelOutput` and remove `channelString`.

All the references of `Force` method are updated to reflect the change in signature.

