### PR TITLE
Implementation of Force Current Sequencing and its helper methods

### DIFF
--- a/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/DCPower/Source.cs
+++ b/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/DCPower/Source.cs
@@ -14,6 +14,8 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
     /// </summary>
     public static class Source
     {
+        private const double DefaultSequenceTimeOut = 5;
+
         #region methods on DCPowerSessionsBundle
 
         /// <summary>
@@ -493,7 +495,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
             double? voltageLimitRange = null,
             int sequenceLoopCount = 1,
             bool waitForSequenceCompletion = false,
-            double sequenceTimeoutInSeconds = 5.0)
+            double sequenceTimeoutInSeconds = DefaultSequenceTimeOut)
         {
             sessionsBundle.Do(sessionInfo =>
             {
@@ -519,7 +521,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
             double? voltageLimitRange = null,
             int sequenceLoopCount = 1,
             bool waitForSequenceCompletion = false,
-            double sequenceTimeoutInSeconds = 5.0)
+            double sequenceTimeoutInSeconds = DefaultSequenceTimeOut)
         {
             sessionsBundle.Do((sessionInfo, sitePinInfo) =>
             {
@@ -549,7 +551,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
             double? voltageLimitRange = null,
             int sequenceLoopCount = 1,
             bool waitForSequenceCompletion = false,
-            double sequenceTimeoutInSeconds = 5.0)
+            double sequenceTimeoutInSeconds = DefaultSequenceTimeOut)
         {
             sessionsBundle.Do((sessionInfo, sitePinInfo) =>
             {
@@ -766,22 +768,22 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
         /// <inheritdoc cref="ConfigureSequence(DCPowerSessionsBundle, double[], int, double?)"/>
         public static void ConfigureSequence(this DCPowerSessionsBundle sessionsBundle, SiteData<double[]> sequence, int sequenceLoopCount = 1, double? sequenceStepDeltaTimeInSeconds = null)
         {
-            sessionsBundle.Do((sessionInfo, pinSiteInfo) =>
+            sessionsBundle.Do((sessionInfo, sitePinInfo) =>
             {
-                var channelOutput = sessionInfo.Session.Outputs[pinSiteInfo.IndividualChannelString];
+                var channelOutput = sessionInfo.Session.Outputs[sitePinInfo.IndividualChannelString];
                 channelOutput.Control.Abort();
-                channelOutput.ConfigureSequence(sequence.GetValue(pinSiteInfo.SiteNumber), sequenceLoopCount, sequenceStepDeltaTimeInSeconds);
+                channelOutput.ConfigureSequence(sequence.GetValue(sitePinInfo.SiteNumber), sequenceLoopCount, sequenceStepDeltaTimeInSeconds);
             });
         }
 
         /// <inheritdoc cref="ConfigureSequence(DCPowerSessionsBundle, double[], int, double?)"/>
         public static void ConfigureSequence(this DCPowerSessionsBundle sessionsBundle, PinSiteData<double[]> sequence, int sequenceLoopCount = 1, double? sequenceStepDeltaTimeInSeconds = null)
         {
-            sessionsBundle.Do((sessionInfo, pinSiteInfo) =>
+            sessionsBundle.Do((sessionInfo, sitePinInfo) =>
             {
-                var channelOutput = sessionInfo.Session.Outputs[pinSiteInfo.IndividualChannelString];
+                var channelOutput = sessionInfo.Session.Outputs[sitePinInfo.IndividualChannelString];
                 channelOutput.Control.Abort();
-                channelOutput.ConfigureSequence(sequence.GetValue(pinSiteInfo), sequenceLoopCount, sequenceStepDeltaTimeInSeconds);
+                channelOutput.ConfigureSequence(sequence.GetValue(sitePinInfo), sequenceLoopCount, sequenceStepDeltaTimeInSeconds);
             });
         }
 

--- a/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/SourceTests.cs
+++ b/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/SourceTests.cs
@@ -659,12 +659,12 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
 
             sessionsBundle.ConfigureMeasureWhen(DCPowerMeasurementWhen.AutomaticallyAfterSourceComplete);
             var sequence = new SiteData<double[]>(new double[][]
-                        {
-                            new[] { -0.005, 0.010 },  // Site 0
-                            new[] { -0.006, 0.012 },  // Site 1
-                            new[] { 0.007, 0.014 },  // Site 2
-                            new[] { 0.008, 0.016 }
-                        });
+            {
+                new[] { -0.005, 0.010 },
+                new[] { -0.006, 0.012 },
+                new[] { 0.007, 0.014 },
+                new[] { 0.008, 0.016 }
+            });
             sessionsBundle.ForceCurrentSequence(currentSequence: sequence, voltageLimit: 0.5, currentLevelRange: 0.1, voltageLimitRange: 1, sequenceLoopCount: 2);
 
             sessionsBundle.Abort();
@@ -1144,7 +1144,7 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public void DifferentSMUDevices_SetSequenceWithSourceDelaySucceeds(bool pinMapWithChannelGroup)
+        public void DifferentSMUDevices_ConfigureSequenceWithSourceDelaySucceeds(bool pinMapWithChannelGroup)
         {
             var sessionManager = Initialize(pinMapWithChannelGroup);
             var sessionsBundle = sessionManager.DCPower("VDD");


### PR DESCRIPTION
This pull request adds comprehensive support for hardware-timed current source sequencing to the DC Power abstraction layer, including per-site and per-pin configurations, as well as per-step source delays. It also introduces new unit tests to validate these features. The main changes are grouped below:

### New API Methods for Current Sequencing

* Added three overloads of `ForceCurrentSequence` to `DCPowerSessionsBundle` for applying current sequences: one for all channels, one for per-site (`SiteData<double[]>`), and one for per-pin-per-site (`PinSiteData<double[]>`). 

### Sequence Configuration Enhancements

* Added overloads of `ConfigureSequence` to `DCPowerSessionsBundle` for per-site and per-pin-per-site support, enabling flexible configuration of voltage/current sequences with loop counts and step timing.
* Added overloads of `ConfigureSequenceWithSourceDelays` to `DCPowerSessionsBundle` for all channels, per-site, and per-pin-per-site support, allowing configuration of per-step source delays in sequences.
* Added a new method to `DCPowerOutput` for configuring sequences with per-step source delays, integrating time spans for each step.

### Unit Test Coverage

* Added multiple unit tests to `SourceTests.cs` to verify correct behavior of the new sequence APIs, including tests for per-site and per-pin-per-site data, compliance limits, and correct value settings for various hardware configurations.
* Added a new assertion helper to validate current sequence settings, including checks for current level range, voltage limits, and sequence loop count.

For more details : [HLD](https://dev.azure.com/ni/DevCentral/_git/AppCentral.wiki?path=/Organizations/Systems-R%26D/Groups/Semiconductor-(SEBU)/Semi-APT-App-SW/Mixed-Signal-APT/Feature-Specs/26.0/%5BHLD%5D-DC-Power-Hardware-Level-Sequence-Support-in-STL.md&version=GBwikiMaster&_a=preview&anchor=simple-sequence-methods)