### PR TITLE
Implementation for CreateRampSequence and its overloads

### DIFF
--- a/SemiconductorTestLibrary.Extensions/source/Common/HelperMethods.cs
+++ b/SemiconductorTestLibrary.Extensions/source/Common/HelperMethods.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using NationalInstruments.SemiconductorTestLibrary.DataAbstraction;
 
 namespace NationalInstruments.SemiconductorTestLibrary.Common
 {
-    internal static class HelperMethods
+    /// <summary>
+    /// Provides helper methods.
+    /// </summary>
+    public static class HelperMethods
     {
         internal static T GetDistinctValue<T>(IEnumerable<T> values, string errorMessage)
         {
@@ -16,6 +20,56 @@ namespace NationalInstruments.SemiconductorTestLibrary.Common
             {
                 throw new NISemiconductorTestException(errorMessage);
             }
+        }
+
+        /// <summary>
+        /// Creates a ramp sequence of double values from outputStart to outputStop with the specified number of points.
+        /// </summary>
+        /// <param name="outputStart">The starting value of the ramp.</param>
+        /// <param name="outputStop">The ending value of the ramp.</param>
+        /// <param name="numberOfPoints">The number of points in the ramp sequence.</param>
+        /// <returns>An array of double values representing the ramp sequence.</returns>
+        public static double[] CreateRampSequence(double outputStart, double outputStop, double numberOfPoints)
+        {
+            double stepSize = 0.0;
+
+            if (numberOfPoints > 1)
+            {
+                stepSize = (outputStop - outputStart) / (numberOfPoints - 1);
+            }
+            double[] rampSequence = new double[(int)numberOfPoints];
+            for (int i = 0; i < numberOfPoints; i++)
+            {
+                rampSequence[i] = outputStart + (i * (double)stepSize);
+            }
+            return rampSequence;
+        }
+
+        /// <summary>
+        /// Creates a ramp sequence and wraps it in a SiteData object for the specified site numbers.
+        /// </summary>
+        /// <param name="outputStart">The starting value of the ramp.</param>
+        /// <param name="outputStop">The ending value of the ramp.</param>
+        /// <param name="numberOfPoints">The number of points in the ramp sequence.</param>
+        /// <param name="siteNumbers">The site numbers to associate with the ramp sequence.</param>
+        /// <returns>A SiteData object containing the ramp sequence for the specified sites.</returns>
+        public static SiteData<double[]> CreateRampSequence(double outputStart, double outputStop, int numberOfPoints, int[] siteNumbers)
+        {
+            return new SiteData<double[]>(siteNumbers, CreateRampSequence(outputStart, outputStop, numberOfPoints));
+        }
+
+        /// <summary>
+        /// Creates a ramp sequence and wraps it in a PinSiteData object for the specified pin names and site numbers.
+        /// </summary>
+        /// <param name="outputStart">The starting value of the ramp.</param>
+        /// <param name="outputStop">The ending value of the ramp.</param>
+        /// <param name="numberOfPoints">The number of points in the ramp sequence.</param>
+        /// <param name="pinNames">The pin names to associate with the ramp sequence.</param>
+        /// <param name="siteNumbers">The site numbers to associate with the ramp sequence.</param>
+        /// <returns>A PinSiteData object containing the ramp sequence for the specified pins and sites.</returns>
+        public static PinSiteData<double[]> CreateRampSequence(double outputStart, double outputStop, int numberOfPoints, string[] pinNames, int[] siteNumbers)
+        {
+            return new PinSiteData<double[]>(pinNames, siteNumbers, CreateRampSequence(outputStart, outputStop, numberOfPoints));
         }
     }
 }

--- a/SemiconductorTestLibrary.Extensions/tests/Common/HelperMethodsTests.cs
+++ b/SemiconductorTestLibrary.Extensions/tests/Common/HelperMethodsTests.cs
@@ -1,0 +1,100 @@
+﻿using System.Linq;
+using NationalInstruments.SemiconductorTestLibrary.Common;
+using Xunit;
+
+namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.Common
+{
+    public class HelperMethodsTests
+    {
+        [Theory]
+        [InlineData(0.0, 1.0, 5)]
+        [InlineData(-1.0, 1.0, 3)]
+        [InlineData(2.5, 2.5, 1)]
+        public void CreateRampSequence_RampValuesAreCorrect(double start, double stop, int points)
+        {
+            var seq = HelperMethods.CreateRampSequence(start, stop, points);
+
+            Assert.NotNull(seq);
+            Assert.Equal(points, seq.Length);
+            Assert.Equal(start, seq.First());
+            Assert.Equal(stop, seq.Last());
+            if (points == 1)
+            {
+                Assert.Equal(start, seq[0]);
+            }
+            double expectedStep = 0.0;
+            if (points > 1)
+            {
+                expectedStep = (stop - start) / (points - 1);
+            }
+            for (int i = 0; i < points; i++)
+            {
+                Assert.Equal(start + ((double)i * expectedStep), seq[i]);
+            }
+        }
+
+        [Fact]
+        public void CreateRampSequence_RampWithTwoPointsProducesEndsOnly()
+        {
+            var seq = HelperMethods.CreateRampSequence(5.0, 9.0, 2);
+
+            Assert.Equal(new[] { 5.0, 9.0 }, seq);
+        }
+
+        [Fact]
+        public void CreateRampSequenceForSiteData_AllSitesContainSameRampReference()
+        {
+            var sites = new[] { 0, 1, 2 };
+            var siteData = HelperMethods.CreateRampSequence(0.0, 1.0, 4, sites);
+
+            var firstSiteSequence = siteData.GetValue(0);
+            Assert.NotNull(firstSiteSequence);
+            Assert.Equal(4, firstSiteSequence.Length);
+            foreach (var site in sites)
+            {
+                var seq = siteData.GetValue(site);
+                Assert.Same(firstSiteSequence, seq);
+            }
+        }
+
+        [Fact]
+        public void CreateRampSequenceForPinSiteData_AllPinsAllSitesContainSameRampReference()
+        {
+            var pinNames = new[] { "P1", "P2" };
+            var sites = new[] { 0, 1 };
+            var pinSiteData = HelperMethods.CreateRampSequence(-2.0, 2.0, 5, pinNames, sites);
+
+            var seqP1Site0 = pinSiteData.GetValue(0, "P1");
+            var seqP2Site1 = pinSiteData.GetValue(1, "P2");
+            Assert.Equal(5, seqP1Site0.Length);
+            Assert.Equal(-2.0, seqP1Site0.First());
+            Assert.Equal(2.0, seqP1Site0.Last());
+            foreach (var pin in pinNames)
+            {
+                foreach (var site in sites)
+                {
+                    Assert.Same(seqP1Site0, pinSiteData.GetValue(site, pin));
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(10.0, 10.0)]
+        [InlineData(-5.0, -5.0)]
+        public void CreateRampSequence_SinglePointRampProducesConstant(double start, double stop)
+        {
+            var seq = HelperMethods.CreateRampSequence(start, stop, 1);
+
+            Assert.Single(seq);
+            Assert.Equal(start, seq[0]);
+        }
+
+        [Fact]
+        public void CreateRampSequence_DescendingRampValuesCorrect()
+        {
+            var seq = HelperMethods.CreateRampSequence(5.0, 1.0, 5);
+
+            Assert.Equal(new[] { 5.0, 4.0, 3.0, 2.0, 1.0 }, seq);
+        }
+    }
+}


### PR DESCRIPTION
### What does this Pull Request accomplish?
This pull request adds new ramp sequence generation utilities to the `HelperMethods` class and introduces comprehensive unit tests to validate their behavior. The main changes are the addition of methods for creating ramp sequences and wrapping them in domain-specific data structures, as well as making `HelperMethods` public for broader accessibility.

### Why should this Pull Request be merged?
* Added `CreateRampSequence` method to `HelperMethods` to generate an array of double values forming a ramp from a start value to a stop value with a specified number of points.
* Added overloads to wrap the generated ramp sequence in `SiteData<double[]>` and `PinSiteData<double[]>` objects for use with site numbers and pin names, respectively.

* Changed `HelperMethods` from `internal` to `public` and added XML documentation comments to improve discoverability and maintainability.

### What testing has been done?
* Added `HelperMethodsTests` covering ramp sequence creation, including edge cases for single-point ramps, descending ramps, and correct association with sites and pins.
