### PR TITLE
PoC HLS

### DIFF
--- a/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/DCPower/Source.cs
+++ b/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/DCPower/Source.cs
@@ -497,7 +497,15 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
             };
 
             channelOutput.Control.Abort();
-            channelOutput.ConfigureSequence(settings, currentSequence, sequenceLoopCount);
+            channelOutput.ConfigureSequence(currentSequence, sequenceLoopCount);
+            if (settings.OutputFunction.Equals(DCPowerSourceOutputFunction.DCVoltage))
+            {
+                ConfigureVoltageSettings(channelOutput, settings);
+            }
+            else
+            {
+                ConfigureCurrentSettings(channelOutput, settings);
+            }
             channelOutput.InitiateChannels(waitForSequenceCompletion, sequenceTimeoutInSeconds);
         }
 
@@ -870,18 +878,18 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
             }
         }
 
-        private static void ConfigureSequence(this DCPowerOutput output, DCPowerSourceSettings settings, double[] sequence, int sequenceLoopCount)
-        {
-            if (settings.OutputFunction.Equals(DCPowerSourceOutputFunction.DCVoltage))
-            {
-                ConfigureVoltageSettings(output, settings);
-            }
-            else
-            {
-                ConfigureCurrentSettings(output, settings);
-            }
-            output.ConfigureSequence(sequence, sequenceLoopCount);
-        }
+        //private static void ConfigureSequence(this DCPowerOutput output, DCPowerSourceSettings settings, double[] sequence, int sequenceLoopCount)
+        //{
+        //    if (settings.OutputFunction.Equals(DCPowerSourceOutputFunction.DCVoltage))
+        //    {
+        //        ConfigureVoltageSettings(output, settings);
+        //    }
+        //    else
+        //    {
+        //        ConfigureCurrentSettings(output, settings);
+        //    }
+        //    output.ConfigureSequence(sequence, sequenceLoopCount);
+        //}
         #endregion methods on DCPowerOutput
 
         #region methods on NIDCPower session


### PR DESCRIPTION
This a PoC PR for the changes related to `ForceXXSequence`, with the usage of `ConfigureSequence` method.

Reasoning for this approach:
As we are not setting any property which is being set by method `ConfigureSourceSetting` so calling `Force` method seems unnecessary, instead we can use existing `ConfigureSequnce`, and then call initiate after that.

The PoC can be compared with approach which is used in #358 (Specifically `ForceCurrentSequenceCore` implementation)