### PR TITLE
Replace Azure Pipeline GitHub Action with Explicit REST-Based Triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,14 +77,14 @@ jobs:
             PROJECT="DevCentral"
             PAT="${{ secrets.AZURE_DEVOPS_TOKEN }}"
 
-            TIMEOUT=1200   # 20 minutes
-            INTERVAL=30    # check every 30 seconds
+            TIMEOUT=10800   # 3 hour
+            INTERVAL=240    # 4 minutes
             ELAPSED=0
             STATUS="inProgress"
 
             while [ "$STATUS" = "inProgress" ] || [ "$STATUS" = "notStarted" ]; do
               if [[ "$ELAPSED" -ge "$TIMEOUT" ]]; then
-                echo "::error ::Timeout reached after 20 minutes while waiting for Azure DevOps pipeline to complete."
+                echo "::error ::Timeout reached after 3 hours while waiting for Azure DevOps pipeline to complete."
                 exit 1
               fi
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -94,14 +94,14 @@ jobs:
             PROJECT="DevCentral"
             PAT="${{ secrets.AZURE_DEVOPS_TOKEN }}"
 
-            TIMEOUT=1200   # 20 minutes
-            INTERVAL=30    # check every 30 seconds
+            TIMEOUT=10800   # 3 hour
+            INTERVAL=240    # 4 minutes
             ELAPSED=0
             STATUS="inProgress"
 
             while [ "$STATUS" = "inProgress" ] || [ "$STATUS" = "notStarted" ]; do
               if [[ "$ELAPSED" -ge "$TIMEOUT" ]]; then
-                echo "::error ::Timeout reached after 20 minutes while waiting for Azure DevOps pipeline to complete."
+                echo "::error ::Timeout reached after 3 hours while waiting for Azure DevOps pipeline to complete."
                 exit 1
               fi
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -90,14 +90,14 @@ jobs:
             PROJECT="DevCentral"
             PAT="${{ secrets.AZURE_DEVOPS_TOKEN }}"
 
-            TIMEOUT=1200   # 20 minutes
-            INTERVAL=30    # check every 30 seconds
+            TIMEOUT=10800   # 3 hour
+            INTERVAL=240    # 4 minutes
             ELAPSED=0
             STATUS="inProgress"
 
             while [ "$STATUS" = "inProgress" ] || [ "$STATUS" = "notStarted" ]; do
               if [[ "$ELAPSED" -ge "$TIMEOUT" ]]; then
-                echo "::error ::Timeout reached after 20 minutes while waiting for Azure DevOps pipeline to complete."
+                echo "::error ::Timeout reached after 3 hours while waiting for Azure DevOps pipeline to complete."
                 exit 1
               fi
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

- This pull request replaces the third-party `enfa/azure-pipeline-github-action` with explicit Azure DevOps REST API calls across GitHub workflows.
- The updated workflows now trigger Azure DevOps pipelines directly using curl, ensuring consistent branch selection, deterministic variable passing, and clearer execution behaviour.
- The change standardizes how Azure pipelines are triggered and removes reliance on an external GitHub Action.
- [Technical Debt 2929971](https://dev.azure.com/ni/DevCentral/_workitems/edit/2929971)

### Why should this Pull Request be merged?

- Eliminates dependency on a third-party GitHub Action in favour of first-party Azure DevOps APIs, from the following:
  + [CI](https://github.com/ni/semi-test-library-dotnet/blob/main/.github/workflows/ci.yml)
  + [PR Build](https://github.com/ni/semi-test-library-dotnet/blob/main/.github/workflows/pr-build.yml)
  + [PR Test](https://github.com/ni/semi-test-library-dotnet/blob/main/.github/workflows/pr-test.yml)
- Adds 2 steps in each workflow to:
  + Trigger the pipeline
  + Wait for pipeline completion

### What testing has been done?

- [x] Verified GitHub workflows successfully trigger the intended Azure DevOps pipelines using the REST API, by testing PR workflows in a forked repo. [Link to workflow run](https://github.com/Utkarsh-NI-Emerson/forked-semi-test-library-dotnet/actions/runs/21319524823)
- [x] Confirmed required variables are passed correctly and consumed by the Azure pipelines.
- [x] Validated failure handling by observing workflow termination on unsuccessful trigger attempts.
- [x] Ensured existing pipeline behaviour and outputs remain unchanged after the migration.
