### PR TITLE
[SMU Gang Pin Group] - Adding Test for Validating Triggers Disabling When Unganging Pin Group

### DIFF
--- a/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/SourceTests.cs
+++ b/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/SourceTests.cs
@@ -3365,6 +3365,35 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
             Assert.Contains("only supports single channel operation", exception.Message);
         }
 
+        [Fact]
+        public void DifferentSMUDevicesGanged_ConfigureSourceSettingsAndUngangPinGroup_TriggersAreReset()
+        {
+            var sessionManager = Initialize("SMUGangPinGroup_SessionPerChannel.pinmap");
+            var sessionsBundle = sessionManager.DCPower(AllPinsGangedGroup);
+            sessionsBundle.GangPinGroup(AllPinsGangedGroup);
+
+            var settings = new DCPowerSourceSettings()
+            {
+                OutputFunction = DCPowerSourceOutputFunction.DCVoltage,
+                Level = 3,
+                Limit = 1.5
+            };
+            sessionsBundle.ConfigureSourceSettings(settings);
+            sessionsBundle.UngangPinGroup(AllPinsGangedGroup);
+
+            sessionsBundle.Do((sessionInfo, sitePinInfo) =>
+            {
+                if (IsFollowerOfGangedChannels(sitePinInfo.CascadingInfo))
+                {
+                    var channelOutput = sessionInfo.Session.Outputs[sitePinInfo.IndividualChannelString];
+                    Assert.Equal("/SMU_4147_C1_S11/Immediate", channelOutput.Triggers.SourceTrigger.DigitalEdge.InputTerminal);
+                    Assert.Equal("/SMU_4147_C1_S11/Immediate", channelOutput.Triggers.StartTrigger.DigitalEdge.InputTerminal);
+                    Assert.Equal(DCPowerMeasurementWhen.OnDemand, channelOutput.Measurement.MeasureWhen);
+                    Assert.Equal(string.Empty, channelOutput.Triggers.MeasureTrigger.DigitalEdge.InputTerminal);
+                }
+            });
+        }
+
         [Theory]
         [InlineData(false)]
         [InlineData(true)]


### PR DESCRIPTION
### What does this Pull Request accomplish?

This PR adds a test to validate if the triggers are reset when a ganged pin group is unganged.

### Why should this Pull Request be merged?

Triggers that are set to follower channels when a pin group is ganged should be reset when the pin group is unganged. The test added in this PR validates that.

 `DifferentSMUDevicesGanged_ConfigureSourceSettingsAndUngangPinGroup_TriggersAreReset` is the test added and it is passing.

