### PR TITLE
Correct Assembly Description in Extensions Assembly Info

### DIFF
--- a/SemiconductorTestLibrary.Extensions/source/Properties/AssemblyInfo.cs
+++ b/SemiconductorTestLibrary.Extensions/source/Properties/AssemblyInfo.cs
@@ -5,8 +5,8 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("NationalInstruments.SemiconductorTestLibrary.Extentions")]
-[assembly: AssemblyDescription("NI Semiconductor Test Library Abstractions")]
+[assembly: AssemblyTitle("NationalInstruments.SemiconductorTestLibrary.Extensions")]
+[assembly: AssemblyDescription("NI Semiconductor Test Library Extensions")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("National Instruments")]
 [assembly: AssemblyProduct("NationalInstruments.SemiconductorTestLibrary")]


### PR DESCRIPTION
### What does this Pull Request accomplish?

- The current `AssemblyDescription` declaration in the Extensions Assembly Info is incorrect.
- I also noticed that the spelling of "Extensions" is incorrect in the `AssemblyTitle` declaration.

### Why should this Pull Request be merged?

- Updated the Assembly Description: Changed from `NI Semiconductor Test Library Abstractions` to `NI Semiconductor Test Library Extensions`.
- Updated the Assembly Title: Corrected spelling from `Extentions` to `Extensions`.

### What testing has been done?

- [x] Checked the Abstractions and TestStandSteps Assembly Info files for similar errors.
- [x] Ensured we are using correct spellings.
- [x] Checked if the changes are made to the correct Assembly Info file.