### PR TITLE
Error Code Review: Updated ResourceStrings.resx (Extensions) for 26.0

### DIFF
--- a/SemiconductorTestLibrary.Extensions/source/ResourceStrings.resx
+++ b/SemiconductorTestLibrary.Extensions/source/ResourceStrings.resx
@@ -160,7 +160,7 @@
     <value>Output Stop value must be a finite number.</value>
   </data>
   <data name="DCPower_MultipleChannelOutputsDetected" xml:space="preserve">
-    <value>The channelOutput contains more than one channel "{0}". This method overload only supports single channel operation when a valid SitePinInfo object is passed."</value>
+    <value>The channelOutput contains more than one channel {0}. This method overload only supports single-channel operation when a valid SitePinInfo object is passed."</value>
   </data>
   <data name="DCPower_InconsistentAdvancedSequenceProperties" xml:space="preserve">
     <value>Inconsistent advanced sequence properties. The following properties must be either specified or omitted for all steps in the sequence: {0}</value>


### PR DESCRIPTION
Hi team,

This PR includes the updates made as part of the Error Code Review for Semiconductor Test Library 26.0.

### Changes Made
- Incorporated suggested updates provided by @Terenyi, Gergely
- Changes are based on the review document shared (Error Code and Inline Doc Review.docx)
- Updated the changes mentioned as per the Document  in error code across:
  - Extensions
 

