### PR TITLE
[SMU Gang] Measure Workflow Test Fix

### DIFF
--- a/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/DCPower/Measure.cs
+++ b/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/DCPower/Measure.cs
@@ -198,6 +198,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
         public static Tuple<double[][], double[][]> MeasureAndReturnPerInstrumentPerChannelResults(this DCPowerSessionsBundle sessionsBundle)
         {
             sessionsBundle.ClearBacklogIfSoftwareEdgeTrigger();
+            sessionsBundle.SendTriggerIfSoftwareEdgeTrigger();
             return sessionsBundle.DoAndReturnPerInstrumentPerChannelResults(sessionInfo => sessionInfo.MeasureVoltageAndCurrent());
         }
 
@@ -209,6 +210,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
         public static Tuple<PinSiteData<double>, PinSiteData<double>> MeasureAndReturnPerSitePerPinResults(this DCPowerSessionsBundle sessionsBundle)
         {
             sessionsBundle.ClearBacklogIfSoftwareEdgeTrigger();
+            sessionsBundle.SendTriggerIfSoftwareEdgeTrigger();
             return sessionsBundle.DoAndReturnPerSitePerPinResults(sessionInfo => sessionInfo.MeasureVoltageAndCurrent(), caseDescription: string.Empty, VoltagePinSiteResultsFilling, CurrentPinSiteResultsFilling);
         }
 
@@ -220,6 +222,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
         public static PinSiteData<double> MeasureVoltage(this DCPowerSessionsBundle sessionsBundle)
         {
             sessionsBundle.ClearBacklogIfSoftwareEdgeTrigger();
+            sessionsBundle.SendTriggerIfSoftwareEdgeTrigger();
             return sessionsBundle.DoAndReturnPerSitePerPinResults(sessionInfo => sessionInfo.MeasureVoltageAndCurrent().Item1, caseDescription: string.Empty, VoltagePinSiteResultsFilling);
         }
 
@@ -231,6 +234,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
         public static PinSiteData<double> MeasureCurrent(this DCPowerSessionsBundle sessionsBundle)
         {
             sessionsBundle.ClearBacklogIfSoftwareEdgeTrigger();
+            sessionsBundle.SendTriggerIfSoftwareEdgeTrigger();
             return sessionsBundle.DoAndReturnPerSitePerPinResults(sessionInfo => sessionInfo.MeasureVoltageAndCurrent().Item2, caseDescription: string.Empty, CurrentPinSiteResultsFilling);
         }
 
@@ -247,6 +251,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
         public static void MeasureAndPublishVoltage(this DCPowerSessionsBundle sessionsBundle, string publishedDataId, out double[][] voltageMeasurements)
         {
             sessionsBundle.ClearBacklogIfSoftwareEdgeTrigger();
+            sessionsBundle.SendTriggerIfSoftwareEdgeTrigger();
             voltageMeasurements = sessionsBundle.DoAndPublishResults(sessionInfo => sessionInfo.MeasureVoltageAndCurrent().Item1, publishedDataId);
         }
 
@@ -275,6 +280,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
         public static void MeasureAndPublishCurrent(this DCPowerSessionsBundle sessionsBundle, string publishedDataId, out double[][] currentMeasurements)
         {
             sessionsBundle.ClearBacklogIfSoftwareEdgeTrigger();
+            sessionsBundle.SendTriggerIfSoftwareEdgeTrigger();
             currentMeasurements = sessionsBundle.DoAndPublishResults(sessionInfo => sessionInfo.MeasureVoltageAndCurrent().Item2, publishedDataId);
         }
 
@@ -451,6 +457,23 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
             });
         }
 
+        private static void SendTriggerIfSoftwareEdgeTrigger(this DCPowerSessionsBundle sessionsBundle)
+        {
+            sessionsBundle.Do((sessionInfo, sitePinInfo) =>
+            {
+                if (_onDemandOnlyPowerSupplies.Contains(sitePinInfo.ModelString))
+                {
+                    return;
+                }
+                var session = sessionInfo.Session;
+                var channelOutput = session.Outputs[sitePinInfo.IndividualChannelString];
+                if (channelOutput.Measurement.MeasureWhen == DCPowerMeasurementWhen.OnMeasureTrigger && channelOutput.Triggers.MeasureTrigger.Type == DCPowerMeasureTriggerType.SoftwareEdge)
+                {
+                    channelOutput.Triggers.MeasureTrigger.SendSoftwareEdgeTrigger();
+                }
+            });
+        }
+
         #endregion methods on DCPowerSessionsBundle
 
         #region methods on NIDCPower session
@@ -602,16 +625,6 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.DCP
                         switch (dcOutput.Measurement.MeasureWhen)
                         {
                             case DCPowerMeasurementWhen.OnMeasureTrigger:
-                                if (_onDemandOnlyPowerSupplies.Contains(sitePinInfo.ModelString))
-                                {
-                                    break;
-                                }
-                                if (dcOutput.Triggers.MeasureTrigger.Type == DCPowerMeasureTriggerType.SoftwareEdge)
-                                {
-                                    dcOutput.Triggers.MeasureTrigger.SendSoftwareEdgeTrigger();
-                                }
-                                goto case DCPowerMeasurementWhen.AutomaticallyAfterSourceComplete;
-
                             case DCPowerMeasurementWhen.AutomaticallyAfterSourceComplete:
                                 if (_onDemandOnlyPowerSupplies.Contains(sitePinInfo.ModelString))
                                 {

--- a/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/ControlTests.cs
+++ b/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/ControlTests.cs
@@ -66,7 +66,6 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
             var sessionManager = Initialize(pinmap);
             var dcPower = sessionManager.DCPower(new[] { "PowerPins" });
             dcPower.ConfigureMeasureWhen(measureWhen);
-
             if (measureWhen == DCPowerMeasurementWhen.OnMeasureTrigger)
             {
                 dcPower.ConfigureTriggerSoftwareEdge(TriggerType.MeasureTrigger);

--- a/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/ControlTests.cs
+++ b/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/ControlTests.cs
@@ -212,8 +212,6 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
 
         [Theory]
         [Trait(nameof(Platform), nameof(Platform.TesterOnly))]
-        [Trait(nameof(HardwareConfiguration), nameof(HardwareConfiguration.GP3))]
-        [Trait(nameof(HardwareConfiguration), nameof(HardwareConfiguration.Lungyuan))]
         [Trait(nameof(HardwareConfiguration), nameof(HardwareConfiguration.STSNIBCauvery))]
         [InlineData("Mixed Signal Tests.pinmap", DCPowerMeasurementWhen.OnDemand)]
         [InlineData("Mixed Signal Tests.pinmap", DCPowerMeasurementWhen.OnMeasureTrigger)]

--- a/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/ControlTests.cs
+++ b/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/ControlTests.cs
@@ -51,6 +51,33 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
         }
 
         [Theory]
+        [Trait(nameof(Platform), nameof(Platform.TesterOnly))]
+        [Trait(nameof(HardwareConfiguration), nameof(HardwareConfiguration.GP3))]
+        [Trait(nameof(HardwareConfiguration), nameof(HardwareConfiguration.Lungyuan))]
+        [Trait(nameof(HardwareConfiguration), nameof(HardwareConfiguration.STSNIBCauvery))]
+        [InlineData("Mixed Signal Tests.pinmap", DCPowerMeasurementWhen.OnDemand)]
+        [InlineData("Mixed Signal Tests.pinmap", DCPowerMeasurementWhen.OnMeasureTrigger)]
+        [InlineData("Mixed Signal Tests.pinmap", DCPowerMeasurementWhen.AutomaticallyAfterSourceComplete)]
+        [InlineData("Mixed Signal Tests Common Session.pinmap", DCPowerMeasurementWhen.OnDemand)]
+        [InlineData("Mixed Signal Tests Common Session.pinmap", DCPowerMeasurementWhen.OnMeasureTrigger)]
+        [InlineData("Mixed Signal Tests Common Session.pinmap", DCPowerMeasurementWhen.AutomaticallyAfterSourceComplete)]
+        public void ConfigureMeasureWhen_Initiate_DataMeasurementDoesNotTimeOut(string pinmap, DCPowerMeasurementWhen measureWhen)
+        {
+            var sessionManager = Initialize(pinmap);
+            var dcPower = sessionManager.DCPower(new[] { "PowerPins" });
+            dcPower.ConfigureMeasureWhen(measureWhen);
+
+            if (measureWhen == DCPowerMeasurementWhen.OnMeasureTrigger)
+            {
+                dcPower.ConfigureTriggerSoftwareEdge(TriggerType.MeasureTrigger);
+            }
+
+            dcPower.Initiate();
+
+            dcPower.MeasureVoltage();
+        }
+
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public void DifferentSMUDevicesAndConfigureAdvanceSequenceAsInactive_InitiateAdvancedSequences_AdvanceSequenceActivated(bool pinMapWithChannelGroup)
@@ -156,21 +183,24 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
         }
 
         [Theory]
+        [Trait(nameof(Platform), nameof(Platform.TesterOnly))]
         [Trait(nameof(HardwareConfiguration), nameof(HardwareConfiguration.GP3))]
         [Trait(nameof(HardwareConfiguration), nameof(HardwareConfiguration.Lungyuan))]
         [Trait(nameof(HardwareConfiguration), nameof(HardwareConfiguration.STSNIBCauvery))]
         [InlineData("Mixed Signal Tests.pinmap", DCPowerMeasurementWhen.OnDemand)]
         [InlineData("Mixed Signal Tests.pinmap", DCPowerMeasurementWhen.OnMeasureTrigger)]
+        [InlineData("Mixed Signal Tests.pinmap", DCPowerMeasurementWhen.AutomaticallyAfterSourceComplete)]
         [InlineData("Mixed Signal Tests Common Session.pinmap", DCPowerMeasurementWhen.OnDemand)]
         [InlineData("Mixed Signal Tests Common Session.pinmap", DCPowerMeasurementWhen.OnMeasureTrigger)]
-        [InlineData("Mixed Signal Tests.pinmap", DCPowerMeasurementWhen.AutomaticallyAfterSourceComplete)]
         [InlineData("Mixed Signal Tests Common Session.pinmap", DCPowerMeasurementWhen.AutomaticallyAfterSourceComplete)]
-        public void GangPinGroupAndConfigureMeasure_Initiate_DataMeasurementDoesNotTimeOut(string pinmap, DCPowerMeasurementWhen measureWhen)
+        public void GangPinGroupAndConfigureMeasureSettings_Initiate_DataMeasurementDoesNotTimeOut(string pinmap, DCPowerMeasurementWhen measureWhen)
         {
             var sessionManager = Initialize(pinmap);
             var dcPower = sessionManager.DCPower(new[] { "PowerPins" });
             dcPower.GangPinGroup("MergedPowerPins");
-            dcPower.ConfigureMeasureWhen(measureWhen);
+            var dcpowerMeasureSettings = new DCPowerMeasureSettings() { MeasureWhen = measureWhen };
+            dcPower.ConfigureMeasureSettings(dcpowerMeasureSettings);
+
             if (measureWhen == DCPowerMeasurementWhen.OnMeasureTrigger)
             {
                 dcPower.ConfigureTriggerSoftwareEdge(TriggerType.MeasureTrigger);
@@ -179,6 +209,40 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
             dcPower.Initiate();
 
             dcPower.MeasureVoltage();
+            dcPower.UngangPinGroup("MergedPowerPins");
+        }
+
+        [Theory]
+        [Trait(nameof(Platform), nameof(Platform.TesterOnly))]
+        [Trait(nameof(HardwareConfiguration), nameof(HardwareConfiguration.GP3))]
+        [Trait(nameof(HardwareConfiguration), nameof(HardwareConfiguration.Lungyuan))]
+        [Trait(nameof(HardwareConfiguration), nameof(HardwareConfiguration.STSNIBCauvery))]
+        [InlineData("Mixed Signal Tests.pinmap", DCPowerMeasurementWhen.OnDemand)]
+        [InlineData("Mixed Signal Tests.pinmap", DCPowerMeasurementWhen.OnMeasureTrigger)]
+        [InlineData("Mixed Signal Tests.pinmap", DCPowerMeasurementWhen.AutomaticallyAfterSourceComplete)]
+        [InlineData("Mixed Signal Tests Common Session.pinmap", DCPowerMeasurementWhen.OnDemand)]
+        [InlineData("Mixed Signal Tests Common Session.pinmap", DCPowerMeasurementWhen.OnMeasureTrigger)]
+        [InlineData("Mixed Signal Tests Common Session.pinmap", DCPowerMeasurementWhen.AutomaticallyAfterSourceComplete)]
+        public void GangPinGroupAndConfigureMeasureWhen_InitiateAndMeasure_TimeOutOccurs(string pinmap, DCPowerMeasurementWhen measureWhen)
+        {
+            var sessionManager = Initialize(pinmap);
+            var dcPower = sessionManager.DCPower(new[] { "PowerPins" });
+            dcPower.GangPinGroup("MergedPowerPins");
+            dcPower.ConfigureMeasureWhen(measureWhen);
+
+            if (measureWhen == DCPowerMeasurementWhen.OnMeasureTrigger)
+            {
+                dcPower.ConfigureTriggerSoftwareEdge(TriggerType.MeasureTrigger);
+            }
+
+            void InitiateAndMeasureTest()
+            {
+                dcPower.Initiate();
+                dcPower.MeasureVoltage();
+            }
+
+            var exception = Assert.Throws<NISemiconductorTestException>(InitiateAndMeasureTest);
+            Assert.Contains("Fetch timed out while attempting to retrieve measurements", exception.Message);
             dcPower.UngangPinGroup("MergedPowerPins");
         }
     }

--- a/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/ControlTests.cs
+++ b/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/ControlTests.cs
@@ -209,37 +209,5 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
             dcPower.MeasureVoltage();
             dcPower.UngangPinGroup("MergedPowerPins");
         }
-
-        [Theory]
-        [Trait(nameof(Platform), nameof(Platform.TesterOnly))]
-        [Trait(nameof(HardwareConfiguration), nameof(HardwareConfiguration.STSNIBCauvery))]
-        [InlineData("Mixed Signal Tests.pinmap", DCPowerMeasurementWhen.OnDemand)]
-        [InlineData("Mixed Signal Tests.pinmap", DCPowerMeasurementWhen.OnMeasureTrigger)]
-        [InlineData("Mixed Signal Tests.pinmap", DCPowerMeasurementWhen.AutomaticallyAfterSourceComplete)]
-        [InlineData("Mixed Signal Tests Common Session.pinmap", DCPowerMeasurementWhen.OnDemand)]
-        [InlineData("Mixed Signal Tests Common Session.pinmap", DCPowerMeasurementWhen.OnMeasureTrigger)]
-        [InlineData("Mixed Signal Tests Common Session.pinmap", DCPowerMeasurementWhen.AutomaticallyAfterSourceComplete)]
-        public void GangPinGroupAndConfigureMeasureWhen_InitiateAndMeasure_TimeOutOccurs(string pinmap, DCPowerMeasurementWhen measureWhen)
-        {
-            var sessionManager = Initialize(pinmap);
-            var dcPower = sessionManager.DCPower(new[] { "PowerPins" });
-            dcPower.GangPinGroup("MergedPowerPins");
-            dcPower.ConfigureMeasureWhen(measureWhen);
-
-            if (measureWhen == DCPowerMeasurementWhen.OnMeasureTrigger)
-            {
-                dcPower.ConfigureTriggerSoftwareEdge(TriggerType.MeasureTrigger);
-            }
-
-            void InitiateAndMeasureTest()
-            {
-                dcPower.Initiate();
-                dcPower.MeasureVoltage();
-            }
-
-            var exception = Assert.Throws<NISemiconductorTestException>(InitiateAndMeasureTest);
-            Assert.Contains("Fetch timed out while attempting to retrieve measurements", exception.Message);
-            dcPower.UngangPinGroup("MergedPowerPins");
-        }
     }
 }

--- a/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/ControlTests.cs
+++ b/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/ControlTests.cs
@@ -199,7 +199,6 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
             dcPower.GangPinGroup("MergedPowerPins");
             var dcpowerMeasureSettings = new DCPowerMeasureSettings() { MeasureWhen = measureWhen };
             dcPower.ConfigureMeasureSettings(dcpowerMeasureSettings);
-
             if (measureWhen == DCPowerMeasurementWhen.OnMeasureTrigger)
             {
                 dcPower.ConfigureTriggerSoftwareEdge(TriggerType.MeasureTrigger);

--- a/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/SourceTests.cs
+++ b/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/SourceTests.cs
@@ -5023,7 +5023,7 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
             sessionsBundle.ConfigureSourceDelay(0.1);
             var startTime = DateTime.Now;
 
-            sessionsBundle.ForceVoltage(voltageLevel: 1.0, currentLimit: 0.1, waitForSourceCompletion: false);
+            sessionsBundle.ForceVoltage(voltageLevel: 1.0, currentLimit: 0.05, waitForSourceCompletion: false);
             var elapsedTime = (DateTime.Now - startTime).TotalMilliseconds;
 
             // Should return quickly without waiting for source delay
@@ -5043,7 +5043,7 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
 
             sessionsBundle.ForceVoltageSequence(
                 voltageSequence,
-                currentLimit: 0.1,
+                currentLimit: 0.05,
                 sequenceLoopCount: 1,
                 waitForSequenceCompletion: false);
             var elapsedTime = (DateTime.Now - startTime).TotalMilliseconds;
@@ -5062,7 +5062,7 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
             sessionsBundle.ConfigureSourceDelay(0.1);
             var startTime = DateTime.Now;
 
-            sessionsBundle.ForceVoltage(voltageLevel: 3.3, currentLimit: 0.1, waitForSourceCompletion: true);
+            sessionsBundle.ForceVoltage(voltageLevel: 3.3, currentLimit: 0.05, waitForSourceCompletion: true);
             var elapsedTime = (DateTime.Now - startTime).TotalMilliseconds;
 
             if (!_tsmContext.IsSemiconductorModuleInOfflineMode)
@@ -5087,7 +5087,7 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
 
             sessionsBundle.ForceVoltageSequence(
                 voltageSequence,
-                currentLimit: 0.1,
+                currentLimit: 0.05,
                 sequenceLoopCount: 3,
                 waitForSequenceCompletion: true);
             var elapsedTime = (DateTime.Now - startTime).TotalMilliseconds;


### PR DESCRIPTION
### What does this Pull Request accomplish?

This PR Splits the Initiate Measure Test into 3 different test scenarios with testerOnly triat.

1) No Ganging
2) Ganging with ConfigureMeasureSettings
3) Ganging with ConfigureMeasureWhen

### Why should this Pull Request be merged?

This PR fixes the test logic for `Measure Only` workflow under different measurement configurations.

### What testing has been done?

All the 3 test cases are tested on a PXI testsetup.

Configure MeasureWhen test result 👍🏽 
<img width="1602" height="811" alt="image" src="https://github.com/user-attachments/assets/228936eb-74e2-4661-a27c-ba4b4d6fdf5f" />

Gang and MeasureSettings test result 👍🏽 
<img width="1641" height="841" alt="image" src="https://github.com/user-attachments/assets/05b21025-b38c-471b-bdc5-9b09c7010c9b" />

Gang and MeasureWhen Timeout test result 👍🏽  
<img width="1667" height="824" alt="image" src="https://github.com/user-attachments/assets/9893e8a3-8af6-40e8-a768-21bac51b06cd" />


Test results on Cauvery are passing:
<img width="1561" height="730" alt="image" src="https://github.com/user-attachments/assets/b0bc64fb-8fad-4c3f-8638-6c63096a4354" />

