### PR TITLE
Fixed `WaitForEvent` test and added measurement timeout test

### DIFF
--- a/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/MeasureTests.cs
+++ b/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/MeasureTests.cs
@@ -1143,7 +1143,7 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
             var exception = Assert.Throws<NISemiconductorTestException>(MeasureTest);
             var elapsedTime = (DateTime.Now - startTime).TotalSeconds;
             Assert.Contains("Fetch timed out while attempting to retrieve measurements", exception.Message);
-            Assert.InRange(elapsedTime, 20, 30);
+            Assert.InRange(elapsedTime, 20, 25);
             dcPower.UngangPinGroup("MergedPowerPins");
         }
 

--- a/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/MeasureTests.cs
+++ b/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/MeasureTests.cs
@@ -1143,7 +1143,7 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
             var exception = Assert.Throws<NISemiconductorTestException>(MeasureTest);
             var elapsedTime = (DateTime.Now - startTime).TotalSeconds;
             Assert.Contains("Fetch timed out while attempting to retrieve measurements", exception.Message);
-            Assert.InRange(elapsedTime, 20, 35);
+            Assert.InRange(elapsedTime, 20, 39);
             dcPower.UngangPinGroup("MergedPowerPins");
         }
 

--- a/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/MeasureTests.cs
+++ b/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/MeasureTests.cs
@@ -1110,6 +1110,40 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
             dcPower.UngangPinGroup("MergedPowerPins");
         }
 
+        [Theory]
+        [Trait(nameof(Platform), nameof(Platform.TesterOnly))]
+        [Trait(nameof(HardwareConfiguration), nameof(HardwareConfiguration.STSNIBCauvery))]
+        [InlineData("Mixed Signal Tests.pinmap", DCPowerMeasurementWhen.OnDemand)]
+        [InlineData("Mixed Signal Tests.pinmap", DCPowerMeasurementWhen.OnMeasureTrigger)]
+        [InlineData("Mixed Signal Tests.pinmap", DCPowerMeasurementWhen.AutomaticallyAfterSourceComplete)]
+        [InlineData("Mixed Signal Tests Common Session.pinmap", DCPowerMeasurementWhen.OnDemand)]
+        [InlineData("Mixed Signal Tests Common Session.pinmap", DCPowerMeasurementWhen.OnMeasureTrigger)]
+        [InlineData("Mixed Signal Tests Common Session.pinmap", DCPowerMeasurementWhen.AutomaticallyAfterSourceComplete)]
+        [InlineData("Mixed Signal Tests Instrument Session.pinmap", DCPowerMeasurementWhen.OnDemand)]
+        [InlineData("Mixed Signal Tests Instrument Session.pinmap", DCPowerMeasurementWhen.OnMeasureTrigger)]
+        [InlineData("Mixed Signal Tests Instrument Session.pinmap", DCPowerMeasurementWhen.AutomaticallyAfterSourceComplete)]
+        public void GangPinGroupAndConfigureMeasureWhen_Measure_TimeOutOccurs(string pinmap, DCPowerMeasurementWhen measureWhen)
+        {
+            var sessionManager = Initialize(pinmap);
+            var dcPower = sessionManager.DCPower(new[] { "PowerPins" });
+            dcPower.GangPinGroup("MergedPowerPins");
+            dcPower.ConfigureMeasureWhen(measureWhen);
+            if (measureWhen == DCPowerMeasurementWhen.OnMeasureTrigger)
+            {
+                dcPower.ConfigureTriggerSoftwareEdge(TriggerType.MeasureTrigger);
+            }
+            dcPower.Initiate();
+
+            void InitiateAndMeasureTest()
+            {
+                dcPower.MeasureVoltage();
+            }
+
+            var exception = Assert.Throws<NISemiconductorTestException>(InitiateAndMeasureTest);
+            Assert.Contains("Fetch timed out while attempting to retrieve measurements", exception.Message);
+            dcPower.UngangPinGroup("MergedPowerPins");
+        }
+
         private void AssertMeasureWhenSettings(SitePinInfo sitePinInfo, DCPowerOutput channelOutput, DCPowerMeasurementWhen measureWhen)
         {
             if (sitePinInfo.CascadingInfo is GangingInfo gangingInfo && gangingInfo.IsFollower)

--- a/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/MeasureTests.cs
+++ b/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/MeasureTests.cs
@@ -1122,7 +1122,7 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
         [InlineData("Mixed Signal Tests Instrument Session.pinmap", DCPowerMeasurementWhen.OnDemand)]
         [InlineData("Mixed Signal Tests Instrument Session.pinmap", DCPowerMeasurementWhen.OnMeasureTrigger)]
         [InlineData("Mixed Signal Tests Instrument Session.pinmap", DCPowerMeasurementWhen.AutomaticallyAfterSourceComplete)]
-        public void GangPinGroupAndConfigureMeasureWhen_Measure_TimeOutOccurs(string pinmap, DCPowerMeasurementWhen measureWhen)
+        public void GangedPinGroupConfigureMeasureWhenAndInitiate_Measure_TimeOutOccurs(string pinmap, DCPowerMeasurementWhen measureWhen)
         {
             var sessionManager = Initialize(pinmap);
             var dcPower = sessionManager.DCPower(new[] { "PowerPins" });

--- a/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/MeasureTests.cs
+++ b/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/MeasureTests.cs
@@ -1143,7 +1143,7 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
             var exception = Assert.Throws<NISemiconductorTestException>(MeasureTest);
             var elapsedTime = (DateTime.Now - startTime).TotalSeconds;
             Assert.Contains("Fetch timed out while attempting to retrieve measurements", exception.Message);
-            Assert.InRange(elapsedTime, 20, 39);
+            Assert.InRange(elapsedTime, 20, 30);
             dcPower.UngangPinGroup("MergedPowerPins");
         }
 

--- a/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/MeasureTests.cs
+++ b/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/MeasureTests.cs
@@ -1110,7 +1110,7 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
             dcPower.UngangPinGroup("MergedPowerPins");
         }
 
-        [Theory]
+        [Theory(Skip = "Manual Test until the issue is fixed")]
         [Trait(nameof(Platform), nameof(Platform.TesterOnly))]
         [Trait(nameof(HardwareConfiguration), nameof(HardwareConfiguration.STSNIBCauvery))]
         [InlineData("Mixed Signal Tests.pinmap", DCPowerMeasurementWhen.OnDemand)]
@@ -1134,13 +1134,16 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
             }
             dcPower.Initiate();
 
-            void InitiateAndMeasureTest()
+            void MeasureTest()
             {
                 dcPower.MeasureVoltage();
             }
 
-            var exception = Assert.Throws<NISemiconductorTestException>(InitiateAndMeasureTest);
+            var startTime = DateTime.Now;
+            var exception = Assert.Throws<NISemiconductorTestException>(MeasureTest);
+            var elapsedTime = (DateTime.Now - startTime).TotalSeconds;
             Assert.Contains("Fetch timed out while attempting to retrieve measurements", exception.Message);
+            Assert.InRange(elapsedTime, 20, 35);
             dcPower.UngangPinGroup("MergedPowerPins");
         }
 

--- a/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/TriggersAndEventsTests.cs
+++ b/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/TriggersAndEventsTests.cs
@@ -451,7 +451,7 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
         [Trait(nameof(HardwareConfiguration), nameof(HardwareConfiguration.GP3))]
         [Trait(nameof(HardwareConfiguration), nameof(HardwareConfiguration.Lungyuan))]
         [Trait(nameof(HardwareConfiguration), nameof(HardwareConfiguration.STSNIBCauvery))]
-        public void GangedPinGroupForceVoltageSendSoftwareEdgeTrigger_WaitForEvent_DoesNotThrowException()
+        public void GangedPinGroupForceVoltageAndSendSoftwareEdgeTrigger_WaitForEvent_DoesNotThrowException()
         {
             var sessionManager = Initialize("Mixed Signal Tests.pinmap");
             var sessionsBundle = sessionManager.DCPower(new string[] { "VCC1", "VCC2", "VDD", "VDET" });

--- a/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/TriggersAndEventsTests.cs
+++ b/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/DCPower/TriggersAndEventsTests.cs
@@ -451,7 +451,7 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
         [Trait(nameof(HardwareConfiguration), nameof(HardwareConfiguration.GP3))]
         [Trait(nameof(HardwareConfiguration), nameof(HardwareConfiguration.Lungyuan))]
         [Trait(nameof(HardwareConfiguration), nameof(HardwareConfiguration.STSNIBCauvery))]
-        public void GangedPinGroupForceVoltage_WaitForEventAndSendSoftwareEdgeTrigger_DoesNotThrowException()
+        public void GangedPinGroupForceVoltageSendSoftwareEdgeTrigger_WaitForEvent_DoesNotThrowException()
         {
             var sessionManager = Initialize("Mixed Signal Tests.pinmap");
             var sessionsBundle = sessionManager.DCPower(new string[] { "VCC1", "VCC2", "VDD", "VDET" });
@@ -460,10 +460,9 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
             sessionsBundle.Abort();
             sessionsBundle.ConfigureTriggerSoftwareEdge(TriggerType.SourceTrigger);
             sessionsBundle.Initiate();
+            sessionsBundle.SendSoftwareEdgeTrigger(TriggerType.SourceTrigger);
 
-            Parallel.Invoke(
-                () => sessionsBundle.WaitForEvent(EventType.SourceCompleteEvent),
-                () => sessionsBundle.SendSoftwareEdgeTrigger(TriggerType.SourceTrigger));
+            sessionsBundle.WaitForEvent(EventType.SourceCompleteEvent);
 
             sessionsBundle.UngangPinGroup("MergedPowerPins");
             sessionsBundle.ClearTriggers();


### PR DESCRIPTION
### What does this Pull Request accomplish?

This PR modifies the order of execution to be sequential instead of parallel for `WaitForEvent` test. 
This PR also adds the measurement timeout test to run on STS Cauvery. 

### Why should this Pull Request be merged?

This test fixes the intermittent test [failure](https://dev.azure.com/ni/DevCentral/Stratus%20Infrastructure%20(RDSS)/_build/results?buildId=18956958&view=logs&j=9316236d-33d1-5e32-58fc-bdb37708dc8b&t=edd1751f-bed2-567c-1612-2cb34991ce70&l=431) observed in test mode on STS Cauvery and Lungyuan.

### What testing has been done?

The changes are tested in test mode and dev mode on STS Cauvery and Lungyuan testers.  It is working fine and tests are [passing on Lungyuan](https://dev.azure.com/ni/DevCentral/Stratus%20Infrastructure%20(RDSS)/_build/results?buildId=18959822&view=logs&j=9316236d-33d1-5e32-58fc-bdb37708dc8b&t=edd1751f-bed2-567c-1612-2cb34991ce70&l=1020) and [STS Cauvery](https://dev.azure.com/ni/DevCentral/Stratus%20Infrastructure%20(RDSS)/_build/results?buildId=18960794&view=logs&j=9316236d-33d1-5e32-58fc-bdb37708dc8b&t=edd1751f-bed2-567c-1612-2cb34991ce70&l=552). 
