### PR TITLE
Fix the Broken Links in Namespace in GitHub Pages Documentation

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -12,6 +12,7 @@
         }
       ],
       "dest": "SemiconductorTestLibrary",
+      "outputFormat": "apiPage",
       "memberLayout": "separatePages",
       "namespaceLayout": "flattened",
       "properties": {
@@ -29,6 +30,7 @@
         }
       ],
       "dest": "SemiconductorTestLibrary.TestStandSteps",
+      "outputFormat": "apiPage",
       "memberLayout": "separatePages",
       "namespaceLayout": "nested",
       "properties": {


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Currently the Namespace links are broken down into multiple links which is not correct.
- There's a GitHub Issue raised for this: https://github.com/ni/semi-test-library-dotnet/issues/178

### Why should this Pull Request be merged?

- Updated the `docfx.json` to add the `outputFormat` parameter with `apiPage` as value.

### What testing has been done?

- [x] Verified that the links are not broken anymore by locally deploying the site. Ran the automation through this PR branch, where the source links also pointed to main branch.
  <img width="1200" height="600" alt="image" src="https://github.com/user-attachments/assets/8e2d9ebb-33e1-49fb-bfe4-b288a4381f02" />
- [x] Tested by running automation through main branch and making this change to check if the branch pointed to in the Source Links is correct.
  <img width="1200" height="600" alt="image" src="https://github.com/user-attachments/assets/01d84c0d-8600-47da-b7e0-0cf545fe6d70" />