### PR TITLE
Reduced Source Delay to 0.05s in HLS Sequence Style Example

### DIFF
--- a/Examples/source/Sequence/SMUHardwareLevelSequence/Code Modules/TestSteps/ConfigureSMUAdvancedSequence.cs
+++ b/Examples/source/Sequence/SMUHardwareLevelSequence/Code Modules/TestSteps/ConfigureSMUAdvancedSequence.cs
@@ -30,7 +30,7 @@ namespace NationalInstruments.Examples.SemiconductorTestLibrary.SMUHardwareLevel
             // as ConfigureSourceSettings will set Source Mode to SinglePoint.
             dcPowerPins.ConfigureSourceSettings(new DCPowerSourceSettings()
             {
-                SourceDelayInSeconds = 10,
+                SourceDelayInSeconds = 0.05,
                 TransientResponse = DCPowerSourceTransientResponse.Normal,
             });
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

This pull request updates the `ConfigureSMUAdvancedSequence.cs` file by reducing the `SourceDelayInSeconds` for DC power pins. The change ensures that the SMU advanced sequence completes within the configured timeout limits.


### Why should this Pull Request be merged?

- Previously, `SourceDelayInSeconds` was set to **10 seconds**, which caused `waitForSequenceCompletion` (default timeout: **5 seconds**) in `InitiateSMUAdvancedSequence` to time out.
- This resulted in sequence execution failures.
- The value has been reduced from **10 seconds to 0.05 seconds**, ensuring that the total execution time (including the **3-second aperture time**) remains within the allowed timeout window.


### What testing has been done?

- Executed the sequence example on hardware (PXIe and STSCauvery), and the test is passing and working as expected.
