### PR TITLE
[Cherry-Pick] [User Guide] Add Ganging Documentation to the User Guide TOC

### DIFF
--- a/docs/UserGuide/toc.yml
+++ b/docs/UserGuide/toc.yml
@@ -19,6 +19,8 @@
   items:
     - name: SMU Merge Pin Group
       href: SMUMergePinGroup.md
+    - name: SMU Gang Pin Group
+      href: SMUGangPinGroup.md
     - name: Custom Instrument Support
       href: CustomInstrumentSupport.md
 - name: Data Abstraction


### PR DESCRIPTION
## Cherry-pick : PR #522 to `releases/26.0.0` branch.


### What does this Pull Request accomplish?

- The Ganging Documentation was left out of the TOC, thus is not rendering on the GitHub Pages Website.

### Why should this Pull Request be merged?

- Added `SMU Gang Pin Group` (`SMUGangPinGroup.md`) documentation to `docs\UserGuide\toc.yml`.

### What testing has been done?

- Not Required, just an addition to the Table of Contents