### PR TITLE
[POC] Update TMU Extension Methods for Digital Driver C# APIs Backwards Compatibility

### DIFF
--- a/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/Digital/TMU/TmuExtensions.cs
+++ b/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/Digital/TMU/TmuExtensions.cs
@@ -5,17 +5,6 @@ using System.Linq;
 using NationalInstruments.ModularInstruments.NIDigital;
 using NationalInstruments.SemiconductorTestLibrary.Common;
 using NationalInstruments.SemiconductorTestLibrary.DataAbstraction;
-// Following namespaces are required for 26.5
-using DigitalTmu = NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Digital.TMU.DigitalTmu;
-using DigitalTmuCollections = NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Digital.TMU.DigitalTmuCollections;
-using TMUContextManager = NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Digital.TMU.TMUContextManager;
-using TmuAttributes = NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Digital.TMU.TmuAttributes;
-using TmuArmType = NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Digital.TMU.TmuArmType;
-using TmuArmSetting = NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Digital.TMU.TmuArmSetting;
-using TmuDutyCycle = NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Digital.TMU.TmuDutyCycle;
-using TmuPolarity = NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Digital.TMU.TmuPolarity;
-using TmuPulseWidth = NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Digital.TMU.TmuPulseWidth;
-using TmuSourceEvent = NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Digital.TMU.TmuSourceEvent;
 
 namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Digital
 {
@@ -275,27 +264,27 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Dig
         /// </para>
         /// <para>
         /// For rising edge period (<see cref="TmuPolarity.RisingEdge"/>):<br/>
-        /// - <see cref="TmuAttributes.TmuStartSource"/> = the associated pin<br/>
-        /// - <see cref="TmuAttributes.TmuStartSourceEvent"/> = <see cref="TmuSourceEvent.Voh"/><br/>
-        /// - <see cref="TmuAttributes.TmuStartSourceEventPolarity"/> = <see cref="TmuPolarity.RisingEdge"/><br/>
-        /// - <see cref="TmuAttributes.TmuStopSource"/> = same pin as start source<br/>
-        /// - <see cref="TmuAttributes.TmuStopSourceEvent"/> = <see cref="TmuSourceEvent.Voh"/><br/>
-        /// - <see cref="TmuAttributes.TmuStopSourceEventPolarity"/> = <see cref="TmuPolarity.RisingEdge"/><br/>
-        /// - <see cref="TmuAttributes.TmuSamplesToAcquire"/> = value of <paramref name="samplesToAcquire"/> parameter.<br/>
-        /// - <see cref="TmuAttributes.TmuArmType"/> = derived from the value of the <paramref name="armSetting"/> parameter.<br/>
-        /// - <see cref="TmuAttributes.TmuEnabled"/> = <c>true</c>
+        /// - <see cref="DigitalTmuSource.Source"/> (Start) = the associated pin<br/>
+        /// - <see cref="DigitalTmuSource.SourceEvent"/> (Start) = <see cref="TmuSourceEvent.Voh"/><br/>
+        /// - <see cref="DigitalTmuSource.SourceEventPolarity"/> (Start) = <see cref="TmuPolarity.RisingEdge"/><br/>
+        /// - <see cref="DigitalTmuSource.Source"/> (Stop) = same pin as start source<br/>
+        /// - <see cref="DigitalTmuSource.SourceEvent"/> (Stop) = <see cref="TmuSourceEvent.Voh"/><br/>
+        /// - <see cref="DigitalTmuSource.SourceEventPolarity"/> (Stop) = <see cref="TmuPolarity.RisingEdge"/><br/>
+        /// - <see cref="DigitalTmu.SamplesToAcquire"/> = value of <paramref name="samplesToAcquire"/> parameter.<br/>
+        /// - <see cref="DigitalTmu.ArmType"/> = derived from the value of the <paramref name="armSetting"/> parameter.<br/>
+        /// - <see cref="DigitalTmu.Enabled"/> = <c>true</c>
         /// </para>
         /// <para>
         /// For falling edge period (<see cref="TmuPolarity.FallingEdge"/>):<br/>
-        /// - <see cref="TmuAttributes.TmuStartSource"/> = the associated pin<br/>
-        /// - <see cref="TmuAttributes.TmuStartSourceEvent"/> = <see cref="TmuSourceEvent.Vol"/><br/>
-        /// - <see cref="TmuAttributes.TmuStartSourceEventPolarity"/> = <see cref="TmuPolarity.FallingEdge"/><br/>
-        /// - <see cref="TmuAttributes.TmuStopSource"/> = same pin as start source<br/>
-        /// - <see cref="TmuAttributes.TmuStopSourceEvent"/> = <see cref="TmuSourceEvent.Vol"/><br/>
-        /// - <see cref="TmuAttributes.TmuStopSourceEventPolarity"/> = <see cref="TmuPolarity.FallingEdge"/><br/>
-        /// - <see cref="TmuAttributes.TmuSamplesToAcquire"/> = value of <paramref name="samplesToAcquire"/> parameter.<br/>
-        /// - <see cref="TmuAttributes.TmuArmType"/> = derived from the value of the <paramref name="armSetting"/> parameter.<br/>
-        /// - <see cref="TmuAttributes.TmuEnabled"/> = <c>true</c>
+        /// - <see cref="DigitalTmuSource.Source"/> (Start) = the associated pin<br/>
+        /// - <see cref="DigitalTmuSource.SourceEvent"/> (Start) = <see cref="TmuSourceEvent.Vol"/><br/>
+        /// - <see cref="DigitalTmuSource.SourceEventPolarity"/> (Start) = <see cref="TmuPolarity.FallingEdge"/><br/>
+        /// - <see cref="DigitalTmuSource.Source"/> (Stop) = same pin as start source<br/>
+        /// - <see cref="DigitalTmuSource.SourceEvent"/> (Stop) = <see cref="TmuSourceEvent.Vol"/><br/>
+        /// - <see cref="DigitalTmuSource.SourceEventPolarity"/> (Stop) = <see cref="TmuPolarity.FallingEdge"/><br/>
+        /// - <see cref="DigitalTmu.SamplesToAcquire"/> = value of <paramref name="samplesToAcquire"/> parameter.<br/>
+        /// - <see cref="DigitalTmu.ArmType"/> = derived from the value of the <paramref name="armSetting"/> parameter.<br/>
+        /// - <see cref="DigitalTmu.Enabled"/> = <c>true</c>
         /// </para>
         /// If the <paramref name="edgeType"/> parameter is set to<see cref="TmuPolarity.EitherEdge"/>, an exception will be thrown.<br/>
         /// </remarks>
@@ -370,27 +359,27 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Dig
         /// </para>
         /// <para>
         /// For rising edge skew (<see cref="TmuPolarity.RisingEdge"/>):<br/>
-        /// - <see cref="TmuAttributes.TmuStartSource"/> = Reference channel<br/>
-        /// - <see cref="TmuAttributes.TmuStartSourceEvent"/> = <see cref="TmuSourceEvent.Voh"/><br/>
-        /// - <see cref="TmuAttributes.TmuStartSourceEventPolarity"/> = <see cref="TmuPolarity.RisingEdge"/><br/>
-        /// - <see cref="TmuAttributes.TmuStopSource"/> = Target channel<br/>
-        /// - <see cref="TmuAttributes.TmuStopSourceEvent"/> = <see cref="TmuSourceEvent.Voh"/><br/>
-        /// - <see cref="TmuAttributes.TmuStopSourceEventPolarity"/> = <see cref="TmuPolarity.RisingEdge"/><br/>
-        /// - <see cref="TmuAttributes.TmuSamplesToAcquire"/> = value of <paramref name="samplesToAcquire"/> parameter.<br/>
-        /// - <see cref="TmuAttributes.TmuArmType"/> = derived from the value of the <paramref name="armSetting"/> parameter.<br/>
-        /// - <see cref="TmuAttributes.TmuEnabled"/> = <c>true</c>
+        /// - <see cref="DigitalTmuSource.Source"/> (Start) = Reference channel<br/>
+        /// - <see cref="DigitalTmuSource.SourceEvent"/> (Start) = <see cref="TmuSourceEvent.Voh"/><br/>
+        /// - <see cref="DigitalTmuSource.SourceEventPolarity"/> (Start) = <see cref="TmuPolarity.RisingEdge"/><br/>
+        /// - <see cref="DigitalTmuSource.Source"/> (Stop) = Target channel<br/>
+        /// - <see cref="DigitalTmuSource.SourceEvent"/> (Stop) = <see cref="TmuSourceEvent.Voh"/><br/>
+        /// - <see cref="DigitalTmuSource.SourceEventPolarity"/> (Stop) = <see cref="TmuPolarity.RisingEdge"/><br/>
+        /// - <see cref="DigitalTmu.SamplesToAcquire"/> = value of <paramref name="samplesToAcquire"/> parameter.<br/>
+        /// - <see cref="DigitalTmu.ArmType"/> = derived from the value of the <paramref name="armSetting"/> parameter.<br/>
+        /// - <see cref="DigitalTmu.Enabled"/> = <c>true</c>
         /// </para>
         /// <para>
         /// For falling edge skew (<see cref="TmuPolarity.FallingEdge"/>):<br/>
-        /// - <see cref="TmuAttributes.TmuStartSource"/> = Reference channel<br/>
-        /// - <see cref="TmuAttributes.TmuStartSourceEvent"/> = <see cref="TmuSourceEvent.Vol"/><br/>
-        /// - <see cref="TmuAttributes.TmuStartSourceEventPolarity"/> = <see cref="TmuPolarity.FallingEdge"/><br/>
-        /// - <see cref="TmuAttributes.TmuStopSource"/> = Target channel<br/>
-        /// - <see cref="TmuAttributes.TmuStopSourceEvent"/> = <see cref="TmuSourceEvent.Vol"/><br/>
-        /// - <see cref="TmuAttributes.TmuStopSourceEventPolarity"/> = <see cref="TmuPolarity.FallingEdge"/><br/>
-        /// - <see cref="TmuAttributes.TmuSamplesToAcquire"/> = value of <paramref name="samplesToAcquire"/> parameter.<br/>
-        /// - <see cref="TmuAttributes.TmuArmType"/> = derived from the value of the <paramref name="armSetting"/> parameter.<br/>
-        /// - <see cref="TmuAttributes.TmuEnabled"/> = <c>true</c>
+        /// - <see cref="DigitalTmuSource.Source"/> (Start) = Reference channel<br/>
+        /// - <see cref="DigitalTmuSource.SourceEvent"/> (Start) = <see cref="TmuSourceEvent.Vol"/><br/>
+        /// - <see cref="DigitalTmuSource.SourceEventPolarity"/> (Start) = <see cref="TmuPolarity.FallingEdge"/><br/>
+        /// - <see cref="DigitalTmuSource.Source"/> (Stop) = Target channel<br/>
+        /// - <see cref="DigitalTmuSource.SourceEvent"/> (Stop) = <see cref="TmuSourceEvent.Vol"/><br/>
+        /// - <see cref="DigitalTmuSource.SourceEventPolarity"/> (Stop) = <see cref="TmuPolarity.FallingEdge"/><br/>
+        /// - <see cref="DigitalTmu.SamplesToAcquire"/> = value of <paramref name="samplesToAcquire"/> parameter.<br/>
+        /// - <see cref="DigitalTmu.ArmType"/> = derived from the value of the <paramref name="armSetting"/> parameter.<br/>
+        /// - <see cref="DigitalTmu.Enabled"/> = <c>true</c>
         /// </para>
         /// If the <paramref name="edgeType"/> parameter is set to <see cref="TmuPolarity.EitherEdge"/>, an exception will be thrown.
         /// </remarks>
@@ -491,15 +480,15 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Dig
         /// This method sets the following attributes for the assigned TMU resource:
         /// </para>
         /// <para>
-        /// - <see cref="TmuAttributes.TmuStartSource"/> = the associated pin<br/>
-        /// - <see cref="TmuAttributes.TmuStartSourceEvent"/> = <see cref="TmuSourceEvent.Vol"/><br/>
-        /// - <see cref="TmuAttributes.TmuStartSourceEventPolarity"/> = <see cref="TmuPolarity.RisingEdge"/><br/>
-        /// - <see cref="TmuAttributes.TmuStopSource"/> = same pin as start source<br/>
-        /// - <see cref="TmuAttributes.TmuStopSourceEvent"/> = <see cref="TmuSourceEvent.Voh"/><br/>
-        /// - <see cref="TmuAttributes.TmuStopSourceEventPolarity"/> = <see cref="TmuPolarity.RisingEdge"/><br/>
-        /// - <see cref="TmuAttributes.TmuSamplesToAcquire"/> = value of <paramref name="samplesToAcquire"/> parameter.<br/>
-        /// - <see cref="TmuAttributes.TmuArmType"/> = derived from the value of the <paramref name="armSetting"/> parameter.<br/>
-        /// - <see cref="TmuAttributes.TmuEnabled"/> = <c>true</c>
+        /// - <see cref="DigitalTmuSource.Source"/> (Start) = the associated pin<br/>
+        /// - <see cref="DigitalTmuSource.SourceEvent"/> (Start) = <see cref="TmuSourceEvent.Vol"/><br/>
+        /// - <see cref="DigitalTmuSource.SourceEventPolarity"/> (Start) = <see cref="TmuPolarity.RisingEdge"/><br/>
+        /// - <see cref="DigitalTmuSource.Source"/> (Stop) = same pin as start source<br/>
+        /// - <see cref="DigitalTmuSource.SourceEvent"/> (Stop) = <see cref="TmuSourceEvent.Voh"/><br/>
+        /// - <see cref="DigitalTmuSource.SourceEventPolarity"/> (Stop) = <see cref="TmuPolarity.RisingEdge"/><br/>
+        /// - <see cref="DigitalTmu.SamplesToAcquire"/> = value of <paramref name="samplesToAcquire"/> parameter.<br/>
+        /// - <see cref="DigitalTmu.ArmType"/> = derived from the value of the <paramref name="armSetting"/> parameter.<br/>
+        /// - <see cref="DigitalTmu.Enabled"/> = <c>true</c>
         /// </para>
         /// </remarks>
         /// <param name="sessionsBundle">The <see cref="DigitalSessionsBundle"/> object.</param>
@@ -562,15 +551,15 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Dig
         /// This method sets the following attributes for the assigned TMU resource:
         /// </para>
         /// <para>
-        /// - <see cref="TmuAttributes.TmuStartSource"/> = the associated pin<br/>
-        /// - <see cref="TmuAttributes.TmuStartSourceEvent"/> = <see cref="TmuSourceEvent.Voh"/><br/>
-        /// - <see cref="TmuAttributes.TmuStartSourceEventPolarity"/> = <see cref="TmuPolarity.FallingEdge"/><br/>
-        /// - <see cref="TmuAttributes.TmuStopSource"/> = same pin as start source<br/>
-        /// - <see cref="TmuAttributes.TmuStopSourceEvent"/> = <see cref="TmuSourceEvent.Vol"/><br/>
-        /// - <see cref="TmuAttributes.TmuStopSourceEventPolarity"/> = <see cref="TmuPolarity.FallingEdge"/><br/>
-        /// - <see cref="TmuAttributes.TmuSamplesToAcquire"/> = value of <paramref name="samplesToAcquire"/> parameter.<br/>
-        /// - <see cref="TmuAttributes.TmuArmType"/> = derived from the value of the <paramref name="armSetting"/> parameter.<br/>
-        /// - <see cref="TmuAttributes.TmuEnabled"/> = <c>true</c>
+        /// - <see cref="DigitalTmuSource.Source"/> (Start) = the associated pin<br/>
+        /// - <see cref="DigitalTmuSource.SourceEvent"/> (Start) = <see cref="TmuSourceEvent.Voh"/><br/>
+        /// - <see cref="DigitalTmuSource.SourceEventPolarity"/> (Start) = <see cref="TmuPolarity.FallingEdge"/><br/>
+        /// - <see cref="DigitalTmuSource.Source"/> (Stop) = same pin as start source<br/>
+        /// - <see cref="DigitalTmuSource.SourceEvent"/> (Stop) = <see cref="TmuSourceEvent.Vol"/><br/>
+        /// - <see cref="DigitalTmuSource.SourceEventPolarity"/> (Stop) = <see cref="TmuPolarity.FallingEdge"/><br/>
+        /// - <see cref="DigitalTmu.SamplesToAcquire"/> = value of <paramref name="samplesToAcquire"/> parameter.<br/>
+        /// - <see cref="DigitalTmu.ArmType"/> = derived from the value of the <paramref name="armSetting"/> parameter.<br/>
+        /// - <see cref="DigitalTmu.Enabled"/> = <c>true</c>
         /// </para>
         /// </remarks>
         /// <param name="sessionsBundle">The <see cref="DigitalSessionsBundle"/> object.</param>
@@ -633,26 +622,26 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Dig
         /// </para>
         /// <para>
         /// For duty cycle high (<see cref="TmuDutyCycle.High"/>):<br/>
-        /// - <see cref="TmuAttributes.TmuStartSource"/> = the associated pin<br/>
-        /// - <see cref="TmuAttributes.TmuStartSourceEvent"/> = <see cref="TmuSourceEvent.Voh"/><br/>
-        /// - <see cref="TmuAttributes.TmuStartSourceEventPolarity"/> = <see cref="TmuPolarity.RisingEdge"/><br/>
-        /// - <see cref="TmuAttributes.TmuStopSource"/> = same pin as start source<br/>
-        /// - <see cref="TmuAttributes.TmuStopSourceEvent"/> = <see cref="TmuSourceEvent.Voh"/><br/>
-        /// - <see cref="TmuAttributes.TmuStopSourceEventPolarity"/> = <see cref="TmuPolarity.FallingEdge"/><br/>
+        /// - <see cref="DigitalTmuSource.Source"/> (Start) = the associated pin<br/>
+        /// - <see cref="DigitalTmuSource.SourceEvent"/> (Start) = <see cref="TmuSourceEvent.Voh"/><br/>
+        /// - <see cref="DigitalTmuSource.SourceEventPolarity"/> (Start) = <see cref="TmuPolarity.RisingEdge"/><br/>
+        /// - <see cref="DigitalTmuSource.Source"/> (Stop) = same pin as start source<br/>
+        /// - <see cref="DigitalTmuSource.SourceEvent"/> (Stop) = <see cref="TmuSourceEvent.Voh"/><br/>
+        /// - <see cref="DigitalTmuSource.SourceEventPolarity"/> (Stop) = <see cref="TmuPolarity.FallingEdge"/><br/>
         /// </para>
         /// <para>
         /// For duty cycle low (<see cref="TmuDutyCycle.Low"/>):<br/>
-        /// - <see cref="TmuAttributes.TmuStartSource"/> = the associated pin<br/>
-        /// - <see cref="TmuAttributes.TmuStartSourceEvent"/> = <see cref="TmuSourceEvent.Vol"/><br/>
-        /// - <see cref="TmuAttributes.TmuStartSourceEventPolarity"/> = <see cref="TmuPolarity.FallingEdge"/><br/>
-        /// - <see cref="TmuAttributes.TmuStopSource"/> = same pin as start source<br/>
-        /// - <see cref="TmuAttributes.TmuStopSourceEvent"/> = <see cref="TmuSourceEvent.Vol"/><br/>
-        /// - <see cref="TmuAttributes.TmuStopSourceEventPolarity"/> = <see cref="TmuPolarity.RisingEdge"/><br/>
+        /// - <see cref="DigitalTmuSource.Source"/> (Start) = the associated pin<br/>
+        /// - <see cref="DigitalTmuSource.SourceEvent"/> (Start) = <see cref="TmuSourceEvent.Vol"/><br/>
+        /// - <see cref="DigitalTmuSource.SourceEventPolarity"/> (Start) = <see cref="TmuPolarity.FallingEdge"/><br/>
+        /// - <see cref="DigitalTmuSource.Source"/> (Stop) = same pin as start source<br/>
+        /// - <see cref="DigitalTmuSource.SourceEvent"/> (Stop) = <see cref="TmuSourceEvent.Vol"/><br/>
+        /// - <see cref="DigitalTmuSource.SourceEventPolarity"/> (Stop) = <see cref="TmuPolarity.RisingEdge"/><br/>
         /// </para>
         /// <para>
-        /// - <see cref="TmuAttributes.TmuSamplesToAcquire"/> = value of <paramref name="samplesToAcquire"/> parameter.<br/>
-        /// - <see cref="TmuAttributes.TmuArmType"/> = derived from the value of the <paramref name="armSetting"/> parameter.<br/>
-        /// - <see cref="TmuAttributes.TmuEnabled"/> = <c>true</c>
+        /// - <see cref="DigitalTmu.SamplesToAcquire"/> = value of <paramref name="samplesToAcquire"/> parameter.<br/>
+        /// - <see cref="DigitalTmu.ArmType"/> = derived from the value of the <paramref name="armSetting"/> parameter.<br/>
+        /// - <see cref="DigitalTmu.Enabled"/> = <c>true</c>
         /// </para>
         /// <para>
         /// TMU samples are signed time intervals, so the measurement result can be negative.<br/>
@@ -747,26 +736,26 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Dig
         /// </para>
         /// <para>
         /// For pulse width high (<see cref="TmuPulseWidth.High"/>):<br/>
-        /// - <see cref="TmuAttributes.TmuStartSource"/> = the associated pin<br/>
-        /// - <see cref="TmuAttributes.TmuStartSourceEvent"/> = <see cref="TmuSourceEvent.Voh"/><br/>
-        /// - <see cref="TmuAttributes.TmuStartSourceEventPolarity"/> = <see cref="TmuPolarity.RisingEdge"/><br/>
-        /// - <see cref="TmuAttributes.TmuStopSource"/> = same pin as start source<br/>
-        /// - <see cref="TmuAttributes.TmuStopSourceEvent"/> = <see cref="TmuSourceEvent.Vol"/><br/>
-        /// - <see cref="TmuAttributes.TmuStopSourceEventPolarity"/> = <see cref="TmuPolarity.FallingEdge"/><br/>
+        /// - <see cref="DigitalTmuSource.Source"/> (Start) = the associated pin<br/>
+        /// - <see cref="DigitalTmuSource.SourceEvent"/> (Start) = <see cref="TmuSourceEvent.Voh"/><br/>
+        /// - <see cref="DigitalTmuSource.SourceEventPolarity"/> (Start) = <see cref="TmuPolarity.RisingEdge"/><br/>
+        /// - <see cref="DigitalTmuSource.Source"/> (Stop) = same pin as start source<br/>
+        /// - <see cref="DigitalTmuSource.SourceEvent"/> (Stop) = <see cref="TmuSourceEvent.Vol"/><br/>
+        /// - <see cref="DigitalTmuSource.SourceEventPolarity"/> (Stop) = <see cref="TmuPolarity.FallingEdge"/><br/>
         /// </para>
         /// <para>
         /// For pulse width low (<see cref="TmuPulseWidth.Low"/>):<br/>
-        /// - <see cref="TmuAttributes.TmuStartSource"/> = the associated pin<br/>
-        /// - <see cref="TmuAttributes.TmuStartSourceEvent"/> = <see cref="TmuSourceEvent.Vol"/><br/>
-        /// - <see cref="TmuAttributes.TmuStartSourceEventPolarity"/> = <see cref="TmuPolarity.FallingEdge"/><br/>
-        /// - <see cref="TmuAttributes.TmuStopSource"/> = same pin as start source<br/>
-        /// - <see cref="TmuAttributes.TmuStopSourceEvent"/> = <see cref="TmuSourceEvent.Voh"/><br/>
-        /// - <see cref="TmuAttributes.TmuStopSourceEventPolarity"/> = <see cref="TmuPolarity.RisingEdge"/><br/>
+        /// - <see cref="DigitalTmuSource.Source"/> (Start) = the associated pin<br/>
+        /// - <see cref="DigitalTmuSource.SourceEvent"/> (Start) = <see cref="TmuSourceEvent.Vol"/><br/>
+        /// - <see cref="DigitalTmuSource.SourceEventPolarity"/> (Start) = <see cref="TmuPolarity.FallingEdge"/><br/>
+        /// - <see cref="DigitalTmuSource.Source"/> (Stop) = same pin as start source<br/>
+        /// - <see cref="DigitalTmuSource.SourceEvent"/> (Stop) = <see cref="TmuSourceEvent.Voh"/><br/>
+        /// - <see cref="DigitalTmuSource.SourceEventPolarity"/> (Stop) = <see cref="TmuPolarity.RisingEdge"/><br/>
         /// </para>
         /// <para>
-        /// - <see cref="TmuAttributes.TmuSamplesToAcquire"/> = value of <paramref name="samplesToAcquire"/> parameter.<br/>
-        /// - <see cref="TmuAttributes.TmuArmType"/> = derived from the value of the <paramref name="armSetting"/> parameter.<br/>
-        /// - <see cref="TmuAttributes.TmuEnabled"/> = <c>true</c>
+        /// - <see cref="DigitalTmu.SamplesToAcquire"/> = value of <paramref name="samplesToAcquire"/> parameter.<br/>
+        /// - <see cref="DigitalTmu.ArmType"/> = derived from the value of the <paramref name="armSetting"/> parameter.<br/>
+        /// - <see cref="DigitalTmu.Enabled"/> = <c>true</c>
         /// </para>
         /// <para>
         /// TMU samples are signed time intervals, so the measurement result can be negative.<br/>
@@ -1634,25 +1623,30 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Dig
 
         #endregion
 
-        #region Get TMU Count
+        // #region Get TMU Count
 
-        /// <summary>
-        /// Gets the total number of TMU resources available for each instrument session in the <see cref="DigitalSessionsBundle"/>.
-        /// </summary>
-        /// <remarks>
-        /// This value is session-level and reflects the total TMU count across all modules in each instrument session.
-        /// The returned array contains one value per instrument session, in the same order as <see cref="ISessionsBundle{TSessionInformation}.InstrumentSessions"/>.
-        /// </remarks>
-        /// <param name="sessionsBundle">The <see cref="DigitalSessionsBundle"/>.</param>
-        /// <returns>An array containing the total number of TMU resources available, one value per instrument session.</returns>
-        public static int[] GetTMUCount(this DigitalSessionsBundle sessionsBundle)
-        {
-            return sessionsBundle.InstrumentSessions
-                .Select(sessionInfo => GetDigitalTmus(sessionInfo.Session).GetTmuCount())
-                .ToArray();
-        }
+        // NOTE (POC): GetTMUCount() is temporarily disabled. The driver-native DigitalTmuCollection
+        // (NIDigital.Tmu) only exposes GetDisabledTmuContexts() and GetTmu(string) -- there is no
+        // native API to query the total number of TMU resources available per instrument session.
+        // This needs a follow-up decision on how (or whether) to support this API going forward.
 
-        #endregion
+        // /// <summary>
+        // /// Gets the total number of TMU resources available for each instrument session in the<see cref = "DigitalSessionsBundle" />.
+        // /// </ summary >
+        // /// < remarks >
+        // /// This value is session-level and reflects the total TMU count across all modules in each instrument session.
+        // /// The returned array contains one value per instrument session, in the same order as <see cref = "ISessionsBundle{TSessionInformation}.InstrumentSessions" />.
+        // /// </ remarks >
+        // /// < param name="sessionsBundle">The<see cref = "DigitalSessionsBundle" />.</ param >
+        // ///< returns > An array containing the total number of TMU resources available, one value per instrument session.</returns>
+        // public static int[] GetTMUCount(this DigitalSessionsBundle sessionsBundle)
+        // {
+        //    return sessionsBundle.InstrumentSessions
+        //        .Select(sessionInfo => GetDigitalTmus(sessionInfo.Session).GetTmuCount())
+        //        .ToArray();
+        // }
+
+        // #endregion
 
         private static void AssignTMUContexts(this DigitalSessionInformation digitalSessionInformation, string[] pins = null)
         {
@@ -1869,9 +1863,9 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Dig
             return GetDigitalTmus(sessionInfo.Session).GetTmu(tmuContext);
         }
 
-        private static DigitalTmuCollections GetDigitalTmus(NIDigital session)
+        private static DigitalTmuCollection GetDigitalTmus(NIDigital session)
         {
-            return new DigitalTmuCollections(session);
+            return session.Tmu;
         }
 
         private static void ValidateTmuArmType(TmuArmType armType)

--- a/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/Digital/TMU/TmuExtensions.cs
+++ b/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/Digital/TMU/TmuExtensions.cs
@@ -1623,30 +1623,25 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Dig
 
         #endregion
 
-        // #region Get TMU Count
+        #region Get TMU Count
 
-        // NOTE (POC): GetTMUCount() is temporarily disabled. The driver-native DigitalTmuCollection
-        // (NIDigital.Tmu) only exposes GetDisabledTmuContexts() and GetTmu(string) -- there is no
-        // native API to query the total number of TMU resources available per instrument session.
-        // This needs a follow-up decision on how (or whether) to support this API going forward.
+         /// <summary>
+         /// Gets the total number of TMU resources available for each instrument session in the<see cref = "DigitalSessionsBundle" />.
+         /// </summary>
+         /// <remarks>
+         /// This value is session-level and reflects the total TMU count across all modules in each instrument session.
+         /// The returned array contains one value per instrument session, in the same order as <see cref = "ISessionsBundle{TSessionInformation}.InstrumentSessions" />.
+         /// </remarks>
+         /// <param name="sessionsBundle">The<see cref = "DigitalSessionsBundle" />.</param>
+         /// <returns> An array containing the total number of TMU resources available, one value per instrument session.</returns>
+         public static int[] GetTMUCount(this DigitalSessionsBundle sessionsBundle)
+        {
+            return sessionsBundle.InstrumentSessions
+                .Select(sessionInfo => GetDigitalTmus(sessionInfo.Session).TmuCount())
+                .ToArray();
+        }
 
-        // /// <summary>
-        // /// Gets the total number of TMU resources available for each instrument session in the<see cref = "DigitalSessionsBundle" />.
-        // /// </ summary >
-        // /// < remarks >
-        // /// This value is session-level and reflects the total TMU count across all modules in each instrument session.
-        // /// The returned array contains one value per instrument session, in the same order as <see cref = "ISessionsBundle{TSessionInformation}.InstrumentSessions" />.
-        // /// </ remarks >
-        // /// < param name="sessionsBundle">The<see cref = "DigitalSessionsBundle" />.</ param >
-        // ///< returns > An array containing the total number of TMU resources available, one value per instrument session.</returns>
-        // public static int[] GetTMUCount(this DigitalSessionsBundle sessionsBundle)
-        // {
-        //    return sessionsBundle.InstrumentSessions
-        //        .Select(sessionInfo => GetDigitalTmus(sessionInfo.Session).GetTmuCount())
-        //        .ToArray();
-        // }
-
-        // #endregion
+        #endregion
 
         private static void AssignTMUContexts(this DigitalSessionInformation digitalSessionInformation, string[] pins = null)
         {

--- a/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/Digital/TMU/TmuExtensions.cs
+++ b/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/Digital/TMU/TmuExtensions.cs
@@ -1625,16 +1625,16 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Dig
 
         #region Get TMU Count
 
-         /// <summary>
-         /// Gets the total number of TMU resources available for each instrument session in the<see cref = "DigitalSessionsBundle" />.
-         /// </summary>
-         /// <remarks>
-         /// This value is session-level and reflects the total TMU count across all modules in each instrument session.
-         /// The returned array contains one value per instrument session, in the same order as <see cref = "ISessionsBundle{TSessionInformation}.InstrumentSessions" />.
-         /// </remarks>
-         /// <param name="sessionsBundle">The<see cref = "DigitalSessionsBundle" />.</param>
-         /// <returns> An array containing the total number of TMU resources available, one value per instrument session.</returns>
-         public static int[] GetTMUCount(this DigitalSessionsBundle sessionsBundle)
+        /// <summary>
+        /// Gets the total number of TMU resources available for each instrument session in the <see cref="DigitalSessionsBundle"/>.
+        /// </summary>
+        /// <remarks>
+        /// This value is session-level and reflects the total TMU count across all modules in each instrument session.
+        /// The returned array contains one value per instrument session, in the same order as <see cref="ISessionsBundle{TSessionInformation}.InstrumentSessions"/>.
+        /// </remarks>
+        /// <param name="sessionsBundle">The <see cref="DigitalSessionsBundle"/>.</param>
+        /// <returns>An array containing the total number of TMU resources available, one value per instrument session.</returns>
+        public static int[] GetTMUCount(this DigitalSessionsBundle sessionsBundle)
         {
             return sessionsBundle.InstrumentSessions
                 .Select(sessionInfo => GetDigitalTmus(sessionInfo.Session).TmuCount())

--- a/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/Digital/TMU/TmuExtensionsTests.cs
+++ b/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/Digital/TMU/TmuExtensionsTests.cs
@@ -1,8 +1,8 @@
 using System;
+using NationalInstruments.ModularInstruments.NIDigital;
 using NationalInstruments.SemiconductorTestLibrary.Common;
 using NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction;
 using NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Digital;
-using NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Digital.TMU;
 using NationalInstruments.Tests.SemiconductorTestLibrary.Utilities;
 using NationalInstruments.TestStand.SemiconductorModule.CodeModuleAPI;
 using Xunit;
@@ -1665,27 +1665,29 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
 
         #region Get TMU Count Tests
 
-        [Fact]
-        public void Initialize_GetTMUCountWithTMUAssigned_ReturnsAtLeastTwoTMUs()
-        {
-            var sessionsBundle = InitializeAndCreateBundle();
+        // NOTE (POC): GetTMUCount() is temporarily disabled in TmuExtensions.cs, see note there.
+        // These tests are disabled to match.
+        ////[Fact]
+        ////public void Initialize_GetTMUCountWithTMUAssigned_ReturnsAtLeastTwoTMUs()
+        ////{
+        ////    var sessionsBundle = InitializeAndCreateBundle();
 
-            var result = sessionsBundle.GetTMUCount();
+        ////    var result = sessionsBundle.GetTMUCount();
 
-            Assert.True(Array.TrueForAll(result, count => count >= 2));
-            sessionsBundle.ClearTMUAssignment();
-        }
+        ////    Assert.True(Array.TrueForAll(result, count => count >= 2));
+        ////    sessionsBundle.ClearTMUAssignment();
+        ////}
 
-        [Fact]
-        public void Initialize_GetTMUCountWithoutTMUAssigned_ReturnsAtLeastTwoTMUs()
-        {
-            var sessionManager = InitializeSessionsAndCreateSessionManager();
-            var sessionsBundle = sessionManager.Digital(new string[] { "C0", "C1" });
+        ////[Fact]
+        ////public void Initialize_GetTMUCountWithoutTMUAssigned_ReturnsAtLeastTwoTMUs()
+        ////{
+        ////    var sessionManager = InitializeSessionsAndCreateSessionManager();
+        ////    var sessionsBundle = sessionManager.Digital(new string[] { "C0", "C1" });
 
-            var result = sessionsBundle.GetTMUCount();
+        ////    var result = sessionsBundle.GetTMUCount();
 
-            Assert.True(Array.TrueForAll(result, count => count >= 2));
-        }
+        ////    Assert.True(Array.TrueForAll(result, count => count >= 2));
+        ////}
 
         #endregion
 

--- a/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/Digital/TMU/TmuExtensionsTests.cs
+++ b/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/Digital/TMU/TmuExtensionsTests.cs
@@ -1665,29 +1665,27 @@ namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbst
 
         #region Get TMU Count Tests
 
-        // NOTE (POC): GetTMUCount() is temporarily disabled in TmuExtensions.cs, see note there.
-        // These tests are disabled to match.
-        ////[Fact]
-        ////public void Initialize_GetTMUCountWithTMUAssigned_ReturnsAtLeastTwoTMUs()
-        ////{
-        ////    var sessionsBundle = InitializeAndCreateBundle();
+        [Fact]
+        public void Initialize_GetTMUCountWithTMUAssigned_ReturnsAtLeastTwoTMUs()
+        {
+            var sessionsBundle = InitializeAndCreateBundle();
 
-        ////    var result = sessionsBundle.GetTMUCount();
+            var result = sessionsBundle.GetTMUCount();
 
-        ////    Assert.True(Array.TrueForAll(result, count => count >= 2));
-        ////    sessionsBundle.ClearTMUAssignment();
-        ////}
+            Assert.True(Array.TrueForAll(result, count => count >= 2));
+            sessionsBundle.ClearTMUAssignment();
+        }
 
-        ////[Fact]
-        ////public void Initialize_GetTMUCountWithoutTMUAssigned_ReturnsAtLeastTwoTMUs()
-        ////{
-        ////    var sessionManager = InitializeSessionsAndCreateSessionManager();
-        ////    var sessionsBundle = sessionManager.Digital(new string[] { "C0", "C1" });
+        [Fact]
+        public void Initialize_GetTMUCountWithoutTMUAssigned_ReturnsAtLeastTwoTMUs()
+        {
+            var sessionManager = InitializeSessionsAndCreateSessionManager();
+            var sessionsBundle = sessionManager.Digital(new string[] { "C0", "C1" });
 
-        ////    var result = sessionsBundle.GetTMUCount();
+            var result = sessionsBundle.GetTMUCount();
 
-        ////    Assert.True(Array.TrueForAll(result, count => count >= 2));
-        ////}
+            Assert.True(Array.TrueForAll(result, count => count >= 2));
+        }
 
         #endregion
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

This PR updates the TMU extension methods to use the driver-native TMU APIs exposed by NIDigital driver
- Updated `TmuExtensions.cs` to use `session.Tmu` (native `DigitalTmuCollection`) instead of the removed wrapper collection, and native types.
- Updated `GetDigitalTmus()` to return the native `DigitalTmuCollection` directly from `session.Tmu`.
- Updated XML doc-comment `<see cref>` references to point at native driver members instead of the deleted wrapper types.
- Retained STL-specific behavior with no native equivalent.
- Temporarily commented out `GetTMUCount()` (and its unit tests), since the native `DigitalTmuCollection` does not expose an equivalent count API; to be revisited.
- Updated `TmuExtensionsTests.cs` to remove the stale using for the deleted wrapper namespace and add the native `NationalInstruments.ModularInstruments.NIDigital` namespace.

This is the Extensions-side half of a cross-repo change; the corresponding [AzDO PR](https://dev.azure.com/ni/DevCentral/_git/srd-sebu-mixed-signal-apt/pullrequest/1380670) removes the Facade layer.

### Why should this Pull Request be merged?

- [Work Item](https://dev.azure.com/ni/DevCentral/_workitems/edit/3414935)
- This is a POC PR which can be referred to when STL removes the Facade layer exposing the Native Driver APIs
- Once we remove the Facade layer in the Abstraction for TMU then these changes are to be made for our Extension Methods to be functional.

### What testing has been done?

- [ ] Ran unit tests
- [ ] Solution Build