### PR TITLE
[Scope] Control Class extensions added

### DIFF
--- a/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/Scope/Control.cs
+++ b/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/Scope/Control.cs
@@ -1,0 +1,61 @@
+﻿using static NationalInstruments.SemiconductorTestLibrary.Common.ParallelExecution;
+
+namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Scope
+{
+    /// <summary>
+    /// Defines methods for performing measurements on the NI-Scope session.
+    /// </summary>
+    public static class Control
+    {
+        #region methods on ScopeSessionsBundle
+
+        /// <summary>
+        /// Aborts an in-progress acquisition on all sessions in the bundle.
+        /// </summary>
+        /// <param name="sessionsBundle">The <see cref="ScopeSessionsBundle"/> object.</param>
+        public static void Abort(this ScopeSessionsBundle sessionsBundle)
+        {
+            sessionsBundle.Do(sessionInfo =>
+            {
+                sessionInfo.Session.Measurement.Abort();
+            });
+        }
+
+        /// <summary>
+        /// Performs auto-setup on all sessions in the bundle.
+        /// </summary>
+        /// <param name="sessionsBundle">The <see cref="ScopeSessionsBundle"/> object.</param>
+        public static void AutoSetup(this ScopeSessionsBundle sessionsBundle)
+        {
+            sessionsBundle.Do(sessionInfo =>
+            {
+                sessionInfo.Session.Measurement.AutoSetup();
+            });
+        }
+
+        /// <summary>
+        /// Commits the acquisition on all sessions in the bundle.
+        /// </summary>
+        /// <param name="sessionsBundle">The <see cref="ScopeSessionsBundle"/> object.</param>
+        public static void Commit(this ScopeSessionsBundle sessionsBundle)
+        {
+            sessionsBundle.Do(sessionInfo =>
+            {
+                sessionInfo.Session.Measurement.Commit();
+            });
+        }
+
+        /// <summary>
+        /// Starts acquisition on all sessions in the bundle.
+        /// </summary>
+        /// <param name="sessionsBundle">The <see cref="ScopeSessionsBundle"/> object.</param>
+        public static void Initiate(this ScopeSessionsBundle sessionsBundle)
+        {
+            sessionsBundle.Do(sessionInfo =>
+            {
+                sessionInfo.Session.Measurement.Initiate();
+            });
+        }
+        #endregion methods on ScopeSessionsBundle
+    }
+}

--- a/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/Scope/Control.cs
+++ b/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/Scope/Control.cs
@@ -3,9 +3,8 @@
 namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Scope
 {
     /// <summary>
-    /// Defines methods for performing measurements on the NI-Scope session.
+    /// Defines methods for controlling the NI-Scope session.
     /// </summary>
-    public static class Control
     {
         #region methods on ScopeSessionsBundle
 

--- a/SemiconductorTestLibrary.Extensions/source/SemiconductorTestLibrary.Extensions.csproj
+++ b/SemiconductorTestLibrary.Extensions/source/SemiconductorTestLibrary.Extensions.csproj
@@ -41,6 +41,9 @@
     <Reference Include="NationalInstruments.ModularInstruments.NIFGen.Fx40">
       <SpecificVersion>False</SpecificVersion>
     </Reference>
+    <Reference Include="NationalInstruments.ModularInstruments.NIScope.Fx40">
+        <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="NationalInstruments.ModularInstruments.NISwitch.Fx40">
       <SpecificVersion>False</SpecificVersion>
     </Reference>

--- a/SemiconductorTestLibrary.Extensions/source/SemiconductorTestLibrary.Extensions.csproj
+++ b/SemiconductorTestLibrary.Extensions/source/SemiconductorTestLibrary.Extensions.csproj
@@ -42,7 +42,7 @@
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="NationalInstruments.ModularInstruments.NIScope.Fx40">
-        <SpecificVersion>False</SpecificVersion>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="NationalInstruments.ModularInstruments.NISwitch.Fx40">
       <SpecificVersion>False</SpecificVersion>

--- a/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/Scope/ControlTests.cs
+++ b/SemiconductorTestLibrary.Extensions/tests/Unit/InstrumentAbstraction/Scope/ControlTests.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction;
+using NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Scope;
+using NationalInstruments.TestStand.SemiconductorModule.CodeModuleAPI;
+using Xunit;
+using static NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Scope.InitializeAndClose;
+using static NationalInstruments.Tests.SemiconductorTestLibrary.Utilities.TSMContext;
+
+namespace NationalInstruments.Tests.SemiconductorTestLibrary.Unit.InstrumentAbstraction.Scope
+{
+    [Collection("NonParallelizable")]
+    public sealed class ControlTests : IDisposable
+    {
+        private const string SinglePin = "DUTPin1";
+        private const string PinGroup = "PinGroup";
+
+        private readonly ISemiconductorModuleContext _tsmContext;
+
+        public ControlTests()
+        {
+            _tsmContext = CreateTSMContext("ScopeTests.pinmap");
+            Initialize(_tsmContext);
+        }
+
+        public void Dispose()
+        {
+            Close(_tsmContext);
+        }
+
+        private ScopeSessionsBundle GetSessionsBundle(string pin)
+        {
+            var sessionManager = new TSMSessionManager(_tsmContext);
+            return sessionManager.Scope(pin);
+        }
+
+        [Theory]
+        [InlineData(SinglePin)]
+        [InlineData(PinGroup)]
+        public void InitiatedAcquisition_Abort_Succeeds(string pin)
+        {
+            var sessionsBundle = GetSessionsBundle(pin);
+            sessionsBundle.Initiate();
+
+            sessionsBundle.Abort();
+        }
+
+        [Theory]
+        [InlineData(SinglePin)]
+        [InlineData(PinGroup)]
+        public void SessionsBundle_AutoSetup_Succeeds(string pin)
+        {
+            var sessionsBundle = GetSessionsBundle(pin);
+
+            sessionsBundle.AutoSetup();
+        }
+
+        [Theory]
+        [InlineData(SinglePin)]
+        [InlineData(PinGroup)]
+        public void SessionsBundle_Commit_Succeeds(string pin)
+        {
+            var sessionsBundle = GetSessionsBundle(pin);
+
+            sessionsBundle.Commit();
+        }
+
+        [Theory]
+        [InlineData(SinglePin)]
+        [InlineData(PinGroup)]
+        public void SessionsBundle_Initiate_Succeeds(string pin)
+        {
+            var sessionsBundle = GetSessionsBundle(pin);
+
+            sessionsBundle.Initiate();
+
+            sessionsBundle.Abort();
+        }
+
+        [Fact]
+        public void SessionsBundle_AutoSetupCommitInitiateThenAbort_Succeeds()
+        {
+            var sessionsBundle = GetSessionsBundle(PinGroup);
+
+            sessionsBundle.AutoSetup();
+            sessionsBundle.Commit();
+            sessionsBundle.Initiate();
+            sessionsBundle.Abort();
+        }
+    }
+}


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adds scope control operations for `ScopeSessionsBundle` through the new
`NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Scope.Control`
extension class.

The following operations are supported:

- `Abort`
- `AutoSetup`
- `Commit`
- `Initiate`

Each operation is executed across the sessions in the bundle using the existing
parallel execution mechanism and delegates to the corresponding scope measurement
operation.

The change also:

- Adds `Control.cs` to the Extensions project.
- Adds unit test coverage for the new scope control operations.
- Covers individual operations and the combined
  `AutoSetup → Commit → Initiate → Abort` workflow.

### Why should this Pull Request be merged?

Scope control functionality is required to provide a consistent abstraction for
controlling multiple scope sessions through `ScopeSessionsBundle`.

This change:

- Exposes the standard scope measurement control operations through the
  Semiconductor Test Library abstraction.
- Maintains consistent behavior with the existing parallel session execution
  pattern.
- Enables callers to control all sessions in a bundle without manually iterating
  over individual sessions.
- Adds automated coverage to help prevent regressions in scope acquisition
  control behavior.

### What testing has been done?

Added unit tests covering:

- Aborting an initiated acquisition.
- Scope session auto-setup.
- Committing scope configuration.
- Initiating an acquisition.
- Running the complete auto-setup, commit, initiate, and abort sequence.

The tests use the existing `ScopeTests.pinmap` test context and cover both a
single DUT pin and a pin group.
