### PR TITLE
Update GetTMUCount Method as per Updated Abstractions Implementation

### DIFF
--- a/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/Digital/TMU/TmuExtensions.cs
+++ b/SemiconductorTestLibrary.Extensions/source/InstrumentAbstraction/Digital/TMU/TmuExtensions.cs
@@ -1648,7 +1648,7 @@ namespace NationalInstruments.SemiconductorTestLibrary.InstrumentAbstraction.Dig
         public static int[] GetTMUCount(this DigitalSessionsBundle sessionsBundle)
         {
             return sessionsBundle.InstrumentSessions
-                .Select(sessionInfo => GetDigitalTmus(sessionInfo.Session).GetTmuCount())
+                .Select(sessionInfo => GetDigitalTmus(sessionInfo.Session).TmuCount)
                 .ToArray();
         }
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Updates implementation of `GetTMUCount` method. 
- [Work Item](https://dev.azure.com/ni/DevCentral/_workitems/edit/3414935)

### Why should this Pull Request be merged?

- Updates the method to call into `TmuCount` property and not `GetTmuCount` method.
- This change has been made in Abstractions through [this PR](https://dev.azure.com/ni/DevCentral/_git/srd-sebu-mixed-signal-apt/pullrequest/1399406)

### What testing has been done?

- Ran Unit Tests.
  <img width="429" height="44" alt="image" src="https://github.com/user-attachments/assets/48985c90-69e0-4567-9b5b-a7cd4564f595" />
